### PR TITLE
Implement Trade Cumulus direct-value variation contract

### DIFF
--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -10,6 +10,7 @@ from uuid import uuid4
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from cloud_chamber.bomex_case import BomexCaseError
 from cloud_chamber.cli import ENGINE_NOTE
 from cloud_chamber.cloud_worlds import (
     MORE_MOISTURE_SIMULATION_ID as TRADE_MORE_MOISTURE_SIMULATION_ID,
@@ -213,6 +214,17 @@ from cloud_chamber.trade_cumulus_updraft_lens import (
     WindMode,
     trade_cumulus_updraft_lens_defaults,
     trade_cumulus_updraft_lens_frame,
+)
+from cloud_chamber.trade_cumulus_variations import (
+    TradeCumulusVariationError,
+    TradeCumulusVariationPackage,
+    TradeCumulusVariationPreview,
+    TradeCumulusVariationRequest,
+    TradeCumulusVariationTemplate,
+    create_trade_cumulus_variation,
+    preflight_trade_cumulus_variation,
+    preview_trade_cumulus_variation,
+    trade_cumulus_variation_template,
 )
 from cloud_chamber.visualization_data import (
     ProfileAggregationMethod,
@@ -1176,6 +1188,59 @@ def delete_simulation_saved_view(
             canonical_world_id, simulation_id, settings=settings
         ),
     )
+
+
+@app.get(
+    "/api/worlds/trade-cumulus/variation-template",
+    response_model=TradeCumulusVariationTemplate,
+)
+def get_trade_cumulus_variation_template(
+    parent_simulation_id: str,
+) -> TradeCumulusVariationTemplate:
+    try:
+        return trade_cumulus_variation_template(load_settings(), parent_simulation_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (OSError, TradeCumulusVariationError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post(
+    "/api/worlds/trade-cumulus/variations/preview",
+    response_model=TradeCumulusVariationPreview,
+)
+def preview_trade_cumulus_variation_request(
+    request: TradeCumulusVariationRequest,
+) -> TradeCumulusVariationPreview:
+    try:
+        return preview_trade_cumulus_variation(load_settings(), request)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (OSError, TradeCumulusVariationError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post(
+    "/api/worlds/trade-cumulus/variations",
+    response_model=TradeCumulusVariationPackage,
+)
+def package_trade_cumulus_variation(
+    request: TradeCumulusVariationRequest,
+) -> TradeCumulusVariationPackage:
+    try:
+        return create_trade_cumulus_variation(load_settings(), request)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (OSError, BomexCaseError, TradeCumulusVariationError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/api/worlds/trade-cumulus/variations/preflight")
+def preflight_trade_cumulus_variation_request(request: LaunchRunRequest) -> dict[str, Any]:
+    try:
+        return preflight_trade_cumulus_variation(Path(request.manifest_path).expanduser())
+    except (OSError, ValueError, TradeCumulusVariationError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @app.get(

--- a/app/backend/cloud_chamber/app.py
+++ b/app/backend/cloud_chamber/app.py
@@ -216,11 +216,13 @@ from cloud_chamber.trade_cumulus_updraft_lens import (
     trade_cumulus_updraft_lens_frame,
 )
 from cloud_chamber.trade_cumulus_variations import (
+    TradeCumulusExtendedCharacterizationRequest,
     TradeCumulusVariationError,
     TradeCumulusVariationPackage,
     TradeCumulusVariationPreview,
     TradeCumulusVariationRequest,
     TradeCumulusVariationTemplate,
+    create_trade_cumulus_extended_characterization,
     create_trade_cumulus_variation,
     preflight_trade_cumulus_variation,
     preview_trade_cumulus_variation,
@@ -1229,6 +1231,21 @@ def package_trade_cumulus_variation(
 ) -> TradeCumulusVariationPackage:
     try:
         return create_trade_cumulus_variation(load_settings(), request)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (OSError, BomexCaseError, TradeCumulusVariationError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post(
+    "/api/worlds/trade-cumulus/characterizations/extended-reference",
+    response_model=TradeCumulusVariationPackage,
+)
+def package_trade_cumulus_extended_characterization(
+    request: TradeCumulusExtendedCharacterizationRequest,
+) -> TradeCumulusVariationPackage:
+    try:
+        return create_trade_cumulus_extended_characterization(load_settings(), request)
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except (OSError, BomexCaseError, TradeCumulusVariationError) as exc:

--- a/app/backend/cloud_chamber/cloud_worlds.py
+++ b/app/backend/cloud_chamber/cloud_worlds.py
@@ -31,6 +31,10 @@ from cloud_chamber.run_manifest import (
 from cloud_chamber.saved_comparisons import SavedComparisonError, saved_comparison_count
 from cloud_chamber.settings import CloudChamberSettings
 from cloud_chamber.supercells_world import SupercellsWorldSummary, supercells_world_detail
+from cloud_chamber.trade_cumulus_attempt_provenance import (
+    TradeCumulusAttemptProvenanceError,
+    validate_trade_cumulus_attempt_provenance,
+)
 from cloud_chamber.trade_cumulus_comparison_story import (
     CASE_ID,
     COMPARISON_GROUP_ID,
@@ -57,6 +61,7 @@ from cloud_chamber.variation_envelope import (
     VariationAttempt,
     VariationEnvelope,
     VariationValidationDecision,
+    canonical_payload_sha256,
 )
 
 WORLD_ID: Literal["trade_cumulus"] = "trade_cumulus"
@@ -859,7 +864,7 @@ def _select_variation_backing(
     envelopes: dict[str, VariationEnvelope] = {}
     attempts_by_run: dict[str, VariationAttempt] = {}
     accepted_claims: set[str] = set()
-    identities: set[tuple[str, str]] = set()
+    intended_contracts: set[str] = set()
     conflicts: list[str] = []
 
     for index, candidate in enumerate(ordered):
@@ -888,11 +893,8 @@ def _select_variation_backing(
             conflicts.append(f"Attempt {run_id} is missing its shared variation envelope.")
         if envelope is not None:
             envelopes[run_id] = envelope
-            identities.add(
-                (
-                    envelope.scientific_design.sha256,
-                    envelope.numerical_realization.sha256,
-                )
+            intended_contracts.add(
+                canonical_payload_sha256(_intended_simulation_contract(envelope))
             )
             if candidate.simulation_id != envelope.simulation_id:
                 conflicts.append(f"Attempt {run_id} disagrees with its envelope Simulation ID.")
@@ -923,10 +925,10 @@ def _select_variation_backing(
         conflicts.append(
             "Legacy results grouped under one Simulation ID have no accepted-backing contract."
         )
-    if len(identities) > 1:
+    if len(intended_contracts) > 1:
         conflicts.append(
-            "Attempts grouped under one Simulation ID have different scientific or "
-            "numerical identities."
+            "Attempts grouped under one Simulation ID disagree on the canonical intended "
+            "Simulation contract."
         )
     missing_claims = sorted(accepted_claims - set(by_run))
     if missing_claims:
@@ -1117,13 +1119,34 @@ def _evaluate_variation_parent_eligibility(
         return False, "The retained Simulation lacks valid absolute Recipe controls."
     if controls != normalized:
         return False, "The retained Simulation contains unresolved inactive controls."
-    provenance = manifest.run_configuration.get("cm1_provenance")
-    if not isinstance(provenance, Mapping) or not all(
-        isinstance(provenance.get(key), str) and provenance.get(key)
-        for key in ("source_manifest_sha256", "executable_sha256")
-    ):
-        return False, "Pinned CM1 source and executable identity are unavailable."
+    try:
+        validate_trade_cumulus_attempt_provenance(manifest)
+    except TradeCumulusAttemptProvenanceError as exc:
+        return False, str(exc)
     return True, "Accepted output remains reconstructible inside Recipe contract version 1."
+
+
+def _intended_simulation_contract(envelope: VariationEnvelope) -> dict[str, Any]:
+    """Return every immutable fact that all attempts under one Simulation ID must share."""
+    return {
+        "schema_version": envelope.schema_version,
+        "world_id": envelope.world_id,
+        "recipe_id": envelope.recipe_id,
+        "recipe_contract_version": envelope.recipe_contract_version,
+        "simulation_id": envelope.simulation_id,
+        "parent_simulation_id": envelope.parent_simulation_id,
+        "reference_simulation_id": envelope.reference_simulation_id,
+        "display_name": envelope.display_name,
+        "question": envelope.question,
+        "scientific_design": envelope.scientific_design.model_dump(mode="json"),
+        "numerical_realization": envelope.numerical_realization.model_dump(mode="json"),
+        "observation_plan": envelope.observation_plan.model_dump(mode="json"),
+        "world_payload": envelope.world_payload,
+        "differences": [difference.model_dump(mode="json") for difference in envelope.differences],
+        "relationship_classification": envelope.relationship_classification,
+        "run_profile_id": envelope.run_profile_id,
+        "run_profile_contract": envelope.run_profile_contract,
+    }
 
 
 def _envelope_configuration_differences(

--- a/app/backend/cloud_chamber/cloud_worlds.py
+++ b/app/backend/cloud_chamber/cloud_worlds.py
@@ -790,6 +790,7 @@ def _ordinary_simulations(
                 selection.manifest,
                 selection.manifest_path,
                 envelope,
+                metadata=candidate.metadata,
                 attempts=selection.attempts,
                 accepted_backing=selection.accepted_backing,
             )
@@ -1024,6 +1025,7 @@ def _promote_variation_envelope(
     manifest_path: Path | None,
     envelope: VariationEnvelope,
     *,
+    metadata: ResultMetadata,
     attempts: tuple[VariationAttempt, ...],
     accepted_backing: bool,
 ) -> VariationEnvelope:
@@ -1032,6 +1034,7 @@ def _promote_variation_envelope(
     parent_eligible, parent_reason = _evaluate_variation_parent_eligibility(
         manifest,
         envelope,
+        metadata=metadata,
         accepted_backing=accepted_backing,
     )
     caveated = bool(manifest.run_caveats or manifest.outputs.runtime_warnings)
@@ -1102,10 +1105,16 @@ def _evaluate_variation_parent_eligibility(
     manifest: RunManifest,
     envelope: VariationEnvelope,
     *,
+    metadata: ResultMetadata,
     accepted_backing: bool,
 ) -> tuple[bool, str]:
     if not accepted_backing:
         return False, "Only the accepted backing attempt can parent a new variation."
+    if manifest.run_configuration.get("characterization_authorization") is not None:
+        return (
+            False,
+            "A characterization output requires explicit PM acceptance before it can parent.",
+        )
     if (
         envelope.recipe_id != RECIPE_ID
         or envelope.recipe_contract_version != RECIPE_CONTRACT_VERSION
@@ -1122,6 +1131,10 @@ def _evaluate_variation_parent_eligibility(
     try:
         validate_trade_cumulus_attempt_provenance(manifest)
     except TradeCumulusAttemptProvenanceError as exc:
+        return False, str(exc)
+    try:
+        validate_trade_cumulus_variation_outputs(manifest, metadata)
+    except TradeCumulusOutputValidationError as exc:
         return False, str(exc)
     return True, "Accepted output remains reconstructible inside Recipe contract version 1."
 

--- a/app/backend/cloud_chamber/cloud_worlds.py
+++ b/app/backend/cloud_chamber/cloud_worlds.py
@@ -20,7 +20,14 @@ from cloud_chamber.result_ingest import (
     list_result_metadata,
     result_metadata_from_json,
 )
-from cloud_chamber.run_manifest import LifecycleState, RunManifestError, load_run_manifest
+from cloud_chamber.run_cost import profile_by_id
+from cloud_chamber.run_manifest import (
+    LifecycleState,
+    RunManifest,
+    RunManifestError,
+    load_run_manifest,
+    write_run_manifest,
+)
 from cloud_chamber.saved_comparisons import SavedComparisonError, saved_comparison_count
 from cloud_chamber.settings import CloudChamberSettings
 from cloud_chamber.supercells_world import SupercellsWorldSummary, supercells_world_detail
@@ -34,6 +41,22 @@ from cloud_chamber.trade_cumulus_comparison_story import (
     TradeCumulusComparisonStoryConflict,
     TradeCumulusComparisonStoryNotFound,
     trade_cumulus_moisture_comparison_story,
+)
+from cloud_chamber.trade_cumulus_output_validation import (
+    TradeCumulusOutputValidationError,
+    validate_trade_cumulus_variation_outputs,
+)
+from cloud_chamber.trade_cumulus_recipes import (
+    RECIPE_CONTRACT_VERSION,
+    RECIPE_ID,
+    TradeCumulusControls,
+    default_controls,
+    normalize_controls,
+)
+from cloud_chamber.variation_envelope import (
+    VariationAttempt,
+    VariationEnvelope,
+    VariationValidationDecision,
 )
 
 WORLD_ID: Literal["trade_cumulus"] = "trade_cumulus"
@@ -98,6 +121,7 @@ class SimulationRecord(BaseModel):
     result_id: str
     run_id: str
     source_recipe_id: str | None = None
+    recipe_contract_version: str | None = None
     parent_simulation_id: str | None = None
     reference_simulation_id: str | None = None
     technical_state: TechnicalState
@@ -107,6 +131,15 @@ class SimulationRecord(BaseModel):
     compare_suggestions: list[CompareSuggestion] = Field(default_factory=list)
     configuration_difference_from_reference: list[ConfigurationDifference] | None = None
     lineage_state: LineageState
+    relationship_classification: str | None = None
+    run_profile_id: str | None = None
+    scientific_design: dict[str, Any] | None = None
+    numerical_realization: dict[str, Any] | None = None
+    observation_plan: dict[str, Any] | None = None
+    configuration: dict[str, Any] | None = None
+    can_create_variation: bool = False
+    parent_eligibility_reason: str | None = None
+    attempt_count: int = 1
     created_at: str | None = None
     completed_at: str | None = None
 
@@ -237,6 +270,17 @@ class _LineageCandidate:
     shape_valid: bool
 
 
+@dataclass(frozen=True)
+class _VariationSelection:
+    candidate: _LineageCandidate
+    manifest: RunManifest | None
+    manifest_path: Path | None
+    envelope: VariationEnvelope | None
+    attempts: tuple[VariationAttempt, ...]
+    accepted_backing: bool
+    conflict_reason: str | None = None
+
+
 _REFERENCE_SPEC = _KnownSimulationSpec(
     simulation_id=REFERENCE_SIMULATION_ID,
     display_name=REFERENCE_DISPLAY_NAME,
@@ -353,6 +397,7 @@ def trade_cumulus_world_detail(settings: CloudChamberSettings) -> TradeCumulusWo
         and _is_trade_cumulus_result(metadata)
     ]
     retained, lab_history = _ordinary_simulations(
+        settings,
         other_metadata,
         known_metadata={
             record.record.simulation_id: record.metadata
@@ -361,7 +406,18 @@ def trade_cumulus_world_detail(settings: CloudChamberSettings) -> TradeCumulusWo
         },
     )
 
-    simulations = [reference.record, more_moisture.record, *retained]
+    simulations = [
+        _with_variation_eligibility(settings, record)
+        for record in [reference.record, more_moisture.record, *retained]
+    ]
+    reference = _LoadedKnownSimulation(
+        record=simulations[0],
+        metadata=reference.metadata,
+    )
+    more_moisture = _LoadedKnownSimulation(
+        record=simulations[1],
+        metadata=more_moisture.metadata,
+    )
     lab_summary = _lab_summary(settings, all_metadata, lab_history)
     availability_state, availability_message = _world_availability(
         reference.record, more_moisture.record, featured
@@ -418,6 +474,7 @@ def trade_cumulus_simulation_exists(
         and _is_trade_cumulus_result(metadata)
     ]
     retained, _ = _ordinary_simulations(
+        settings,
         other_metadata,
         known_metadata={
             record.record.simulation_id: record.metadata
@@ -493,6 +550,12 @@ def _known_record(
     inspectability: _Inspectability,
 ) -> SimulationRecord:
     source_recipe = metadata.run_configuration.get("recipe_candidate_id")
+    profile = profile_by_id("trade_cumulus_presentation_v1")
+    controls = default_controls()
+    relationship_classification = None
+    if spec.simulation_id == MORE_MOISTURE_SIMULATION_ID:
+        controls = controls.model_copy(update={"surface_moisture_flux_g_kg_m_s": 0.078})
+        relationship_classification = "controlled_physical_variation"
     return SimulationRecord(
         simulation_id=spec.simulation_id,
         display_name=spec.display_name,
@@ -502,6 +565,7 @@ def _known_record(
         result_id=spec.result_id,
         run_id=spec.run_id,
         source_recipe_id=source_recipe if isinstance(source_recipe, str) else None,
+        recipe_contract_version=RECIPE_CONTRACT_VERSION,
         parent_simulation_id=spec.parent_simulation_id,
         reference_simulation_id=REFERENCE_SIMULATION_ID,
         technical_state=inspectability.technical_state,
@@ -513,6 +577,12 @@ def _known_record(
         ),
         explore_available=inspectability.explore_available,
         lineage_state="known",
+        relationship_classification=relationship_classification,
+        run_profile_id=profile.profile_id,
+        scientific_design={"controls": controls.model_dump(mode="json")},
+        numerical_realization=profile.numerical_realization.model_dump(mode="json"),
+        observation_plan=profile.observation_plan.model_dump(mode="json"),
+        configuration=_trade_configuration_summary(metadata.run_configuration),
         created_at=metadata.created_at.isoformat(),
         completed_at=metadata.updated_at.isoformat(),
     )
@@ -588,22 +658,40 @@ def _featured_comparison(
 
 
 def _ordinary_simulations(
+    settings: CloudChamberSettings,
     metadata_records: list[ResultMetadata],
     *,
     known_metadata: dict[str, ResultMetadata],
 ) -> tuple[list[SimulationRecord], list[SimulationRecord]]:
     candidates = [_lineage_candidate(metadata) for metadata in metadata_records]
-    counts = Counter(
-        candidate.simulation_id for candidate in candidates if candidate.simulation_id is not None
-    )
-    candidate_ids = {
-        candidate.simulation_id
-        for candidate in candidates
-        if candidate.shape_valid
-        and candidate.simulation_id is not None
-        and counts[candidate.simulation_id] == 1
-        and candidate.simulation_id not in _RESERVED_SIMULATION_IDS
+    grouped: dict[str, list[_LineageCandidate]] = {}
+    history: list[SimulationRecord] = []
+    for candidate in candidates:
+        if (
+            not candidate.shape_valid
+            or candidate.simulation_id is None
+            or candidate.simulation_id in _RESERVED_SIMULATION_IDS
+        ):
+            history.append(
+                _lab_history_record(
+                    candidate,
+                    invalid=candidate.supplied_keys,
+                    inspectability=_variation_inspectability(settings, candidate),
+                )
+            )
+            continue
+        grouped.setdefault(candidate.simulation_id, []).append(candidate)
+
+    selections = {
+        simulation_id: _select_variation_backing(settings, grouped_candidates)
+        for simulation_id, grouped_candidates in grouped.items()
     }
+    selected_candidates = {
+        simulation_id: selection.candidate
+        for simulation_id, selection in selections.items()
+        if selection.conflict_reason is None
+    }
+    candidate_ids = set(selected_candidates)
     known_ids = set(known_metadata)
     resolvable_ids = known_ids | candidate_ids
     result_to_simulation = {
@@ -611,29 +699,23 @@ def _ordinary_simulations(
     }
     result_to_simulation.update(
         {
-            candidate.metadata.result_id: candidate.simulation_id
-            for candidate in candidates
-            if candidate.simulation_id in candidate_ids
+            candidate.metadata.result_id: simulation_id
+            for simulation_id, candidate in selected_candidates.items()
         }
     )
-    candidates_by_id = {
-        candidate.simulation_id: candidate
-        for candidate in candidates
-        if candidate.simulation_id in candidate_ids
-    }
+    counts = Counter({simulation_id: 1 for simulation_id in candidate_ids})
     structurally_valid_ids = {
-        candidate.simulation_id
-        for candidate in candidates
+        simulation_id
+        for simulation_id, candidate in selected_candidates.items()
         if _lineage_resolves(
             candidate,
             counts=counts,
             resolvable_ids=resolvable_ids,
             result_to_simulation=result_to_simulation,
         )
-        and candidate.simulation_id is not None
     }
     valid_candidate_ids = structurally_valid_ids - _cyclic_lineage_ids(
-        candidates_by_id,
+        selected_candidates,
         structurally_valid_ids=structurally_valid_ids,
         result_to_simulation=result_to_simulation,
     )
@@ -644,7 +726,7 @@ def _ordinary_simulations(
             if any(
                 target_id in candidate_ids and target_id not in valid_candidate_ids
                 for target_id in _resolved_lineage_target_ids(
-                    candidates_by_id[simulation_id], result_to_simulation
+                    selected_candidates[simulation_id], result_to_simulation
                 )
             )
         }
@@ -654,22 +736,29 @@ def _ordinary_simulations(
     metadata_by_simulation = dict(known_metadata)
     metadata_by_simulation.update(
         {
-            candidate.simulation_id: candidate.metadata
-            for candidate in candidates
-            if candidate.simulation_id in valid_candidate_ids
+            simulation_id: selected_candidates[simulation_id].metadata
+            for simulation_id in valid_candidate_ids
         }
     )
 
     retained: list[SimulationRecord] = []
-    history: list[SimulationRecord] = []
-    for candidate in candidates:
-        valid = candidate.simulation_id in valid_candidate_ids
-        inspectability = _inspectability(candidate.metadata)
-        if not valid:
+    for simulation_id, selection in selections.items():
+        candidate = selection.candidate
+        inspectability = _variation_inspectability(settings, candidate)
+        valid = simulation_id in valid_candidate_ids and selection.conflict_reason is None
+        if not valid or (
+            selection.envelope is not None and inspectability.technical_state != "available"
+        ):
+            if selection.conflict_reason:
+                inspectability = _Inspectability(
+                    technical_state="conflict",
+                    technical_state_message=selection.conflict_reason,
+                    explore_available=False,
+                )
             history.append(
                 _lab_history_record(
                     candidate,
-                    invalid=candidate.supplied_keys,
+                    invalid=True,
                     inspectability=inspectability,
                 )
             )
@@ -685,14 +774,23 @@ def _ordinary_simulations(
             else None
         )
         comparison_parent_id = parent_id or reference_id
-        differences = None
-        if comparison_parent_id is not None:
+        envelope = selection.envelope
+        differences = _envelope_configuration_differences(envelope)
+        if differences is None and comparison_parent_id is not None:
             parent_metadata = metadata_by_simulation.get(comparison_parent_id)
             if parent_metadata is not None:
                 differences = configuration_differences(parent_metadata, candidate.metadata)
+        if envelope is not None:
+            envelope = _promote_variation_envelope(
+                selection.manifest,
+                selection.manifest_path,
+                envelope,
+                attempts=selection.attempts,
+                accepted_backing=selection.accepted_backing,
+            )
         retained.append(
             SimulationRecord(
-                simulation_id=candidate.simulation_id,
+                simulation_id=simulation_id,
                 display_name=candidate.display_name or "Retained Trade Cumulus Simulation",
                 role="variation",
                 product_slice_id=PRODUCT_SLICE_ID,
@@ -712,6 +810,30 @@ def _ordinary_simulations(
                 explore_available=inspectability.explore_available,
                 configuration_difference_from_reference=differences,
                 lineage_state="valid",
+                recipe_contract_version=(
+                    envelope.recipe_contract_version if envelope is not None else None
+                ),
+                relationship_classification=(
+                    envelope.relationship_classification if envelope is not None else None
+                ),
+                run_profile_id=envelope.run_profile_id if envelope is not None else None,
+                scientific_design=(
+                    envelope.scientific_design.payload if envelope is not None else None
+                ),
+                numerical_realization=(
+                    envelope.numerical_realization.payload if envelope is not None else None
+                ),
+                observation_plan=(
+                    envelope.observation_plan.payload if envelope is not None else None
+                ),
+                configuration=_trade_configuration_summary(candidate.metadata.run_configuration),
+                can_create_variation=(envelope.parent_eligible if envelope is not None else False),
+                parent_eligibility_reason=(
+                    envelope.parent_eligibility_reason
+                    if envelope is not None
+                    else "This Simulation predates the shared Recipe envelope."
+                ),
+                attempt_count=len(selection.attempts),
                 created_at=candidate.metadata.created_at.isoformat(),
                 completed_at=candidate.metadata.updated_at.isoformat(),
             )
@@ -719,6 +841,319 @@ def _ordinary_simulations(
     retained.sort(key=lambda record: (record.display_name, record.simulation_id or ""))
     history.sort(key=lambda record: (record.completed_at or "", record.result_id), reverse=True)
     return retained, history
+
+
+def _select_variation_backing(
+    settings: CloudChamberSettings,
+    candidates: list[_LineageCandidate],
+) -> _VariationSelection:
+    ordered = sorted(
+        candidates,
+        key=lambda candidate: (
+            candidate.metadata.created_at.isoformat(),
+            candidate.metadata.run_id,
+        ),
+    )
+    by_run = {candidate.metadata.run_id: candidate for candidate in ordered}
+    manifests: dict[str, tuple[RunManifest, Path]] = {}
+    envelopes: dict[str, VariationEnvelope] = {}
+    attempts_by_run: dict[str, VariationAttempt] = {}
+    accepted_claims: set[str] = set()
+    identities: set[tuple[str, str]] = set()
+    conflicts: list[str] = []
+
+    for index, candidate in enumerate(ordered):
+        run_id = candidate.metadata.run_id
+        manifest_path = settings.runtime_home.expanduser() / "runs" / run_id / "run_manifest.json"
+        manifest: RunManifest | None = None
+        if manifest_path.is_file():
+            try:
+                manifest = load_run_manifest(manifest_path)
+            except (OSError, RunManifestError):
+                conflicts.append(f"Attempt {run_id} has an unreadable run manifest.")
+        if manifest is not None:
+            manifests[run_id] = (manifest, manifest_path)
+        payload = (
+            manifest.run_configuration.get("variation_envelope")
+            if manifest is not None
+            else candidate.metadata.run_configuration.get("variation_envelope")
+        )
+        envelope: VariationEnvelope | None = None
+        if isinstance(payload, Mapping):
+            try:
+                envelope = VariationEnvelope.model_validate(payload)
+            except ValueError:
+                conflicts.append(f"Attempt {run_id} has an invalid shared variation envelope.")
+        elif candidate.metadata.scenario_id == "trade_cumulus_recipe_variation_v1":
+            conflicts.append(f"Attempt {run_id} is missing its shared variation envelope.")
+        if envelope is not None:
+            envelopes[run_id] = envelope
+            identities.add(
+                (
+                    envelope.scientific_design.sha256,
+                    envelope.numerical_realization.sha256,
+                )
+            )
+            if candidate.simulation_id != envelope.simulation_id:
+                conflicts.append(f"Attempt {run_id} disagrees with its envelope Simulation ID.")
+            for attempt in envelope.attempts:
+                attempts_by_run[attempt.run_id] = attempt
+                if attempt.accepted_backing:
+                    accepted_claims.add(attempt.run_id)
+            attempts_by_run.setdefault(
+                run_id,
+                VariationAttempt(
+                    attempt_id=run_id,
+                    run_id=run_id,
+                    relationship="initial" if index == 0 else "unchanged_retry",
+                    package_identity_sha256=(
+                        envelope.package_identity_sha256 or envelope.scientific_design.sha256
+                    ),
+                ),
+            )
+        else:
+            attempts_by_run[run_id] = VariationAttempt(
+                attempt_id=run_id,
+                run_id=run_id,
+                relationship="initial" if index == 0 else "unchanged_retry",
+                package_identity_sha256=run_id,
+            )
+
+    if len(ordered) > 1 and not envelopes:
+        conflicts.append(
+            "Legacy results grouped under one Simulation ID have no accepted-backing contract."
+        )
+    if len(identities) > 1:
+        conflicts.append(
+            "Attempts grouped under one Simulation ID have different scientific or "
+            "numerical identities."
+        )
+    missing_claims = sorted(accepted_claims - set(by_run))
+    if missing_claims:
+        conflicts.append(
+            "Accepted-backing claims reference missing retained attempts: "
+            + ", ".join(missing_claims)
+        )
+    if len(accepted_claims) > 1:
+        conflicts.append(
+            "Multiple attempts claim accepted backing: " + ", ".join(sorted(accepted_claims))
+        )
+
+    accepted_run_id = next(iter(accepted_claims), None) if len(accepted_claims) == 1 else None
+    if accepted_run_id is None and not conflicts:
+        for candidate in ordered:
+            inspectability = _variation_inspectability(settings, candidate)
+            if inspectability.technical_state == "available":
+                accepted_run_id = candidate.metadata.run_id
+                break
+
+    selected = (
+        by_run[accepted_run_id]
+        if accepted_run_id is not None and accepted_run_id in by_run
+        else ordered[-1]
+    )
+    selected_manifest, selected_manifest_path = manifests.get(
+        selected.metadata.run_id, (None, None)
+    )
+    selected_envelope = envelopes.get(selected.metadata.run_id)
+    attempts = tuple(
+        attempt.model_copy(update={"accepted_backing": run_id == accepted_run_id})
+        for run_id, attempt in sorted(
+            attempts_by_run.items(),
+            key=lambda item: (
+                by_run[item[0]].metadata.created_at.isoformat() if item[0] in by_run else "",
+                item[0],
+            ),
+        )
+    )
+    return _VariationSelection(
+        candidate=selected,
+        manifest=selected_manifest,
+        manifest_path=selected_manifest_path,
+        envelope=selected_envelope,
+        attempts=attempts,
+        accepted_backing=accepted_run_id is not None,
+        conflict_reason=" ".join(dict.fromkeys(conflicts)) or None,
+    )
+
+
+def _variation_inspectability(
+    settings: CloudChamberSettings,
+    candidate: _LineageCandidate,
+) -> _Inspectability:
+    base = _inspectability(candidate.metadata)
+    if base.technical_state != "available":
+        return base
+    if candidate.metadata.scenario_id != "trade_cumulus_recipe_variation_v1":
+        return base
+    manifest_path = (
+        settings.runtime_home.expanduser()
+        / "runs"
+        / candidate.metadata.run_id
+        / "run_manifest.json"
+    )
+    try:
+        manifest = load_run_manifest(manifest_path)
+        validate_trade_cumulus_variation_outputs(manifest, candidate.metadata)
+    except (
+        OSError,
+        RunManifestError,
+        TradeCumulusOutputValidationError,
+        ValueError,
+    ) as exc:
+        return _Inspectability(
+            technical_state="conflict",
+            technical_state_message=(
+                "Retained Trade Cumulus output failed contract validation: " + str(exc)
+            ),
+            explore_available=False,
+        )
+    return _Inspectability(
+        technical_state="available",
+        technical_state_message=(
+            "Complete native output passed the Trade Cumulus Recipe and Explore contract."
+        ),
+        explore_available=True,
+    )
+
+
+def _promote_variation_envelope(
+    manifest: RunManifest | None,
+    manifest_path: Path | None,
+    envelope: VariationEnvelope,
+    *,
+    attempts: tuple[VariationAttempt, ...],
+    accepted_backing: bool,
+) -> VariationEnvelope:
+    if manifest is None or manifest_path is None:
+        return envelope
+    parent_eligible, parent_reason = _evaluate_variation_parent_eligibility(
+        manifest,
+        envelope,
+        accepted_backing=accepted_backing,
+    )
+    caveated = bool(manifest.run_caveats or manifest.outputs.runtime_warnings)
+    replacements = {
+        "attempt_integrity": (
+            "passed",
+            (
+                "Generated inputs, normal completion, and accepted-backing selection are coherent."
+                if accepted_backing
+                else "This complete attempt remains alternate output."
+            ),
+        ),
+        "output_completeness": (
+            "passed",
+            "Expected native histories, fields, coordinates, units, and cadence passed.",
+        ),
+        "world_inspectability": (
+            "passed",
+            "Trade Cumulus Explore and the Updraft Lens can inspect the retained output.",
+        ),
+        "availability": (
+            "caveated" if caveated else "passed",
+            (
+                "Simulation is available with retained runtime caveats."
+                if caveated
+                else "Simulation is available."
+            ),
+        ),
+        "parent_eligibility": (
+            "passed" if parent_eligible else "failed",
+            parent_reason,
+        ),
+    }
+    retained = [
+        decision for decision in envelope.validation_decisions if decision.stage not in replacements
+    ]
+    updated = envelope.model_copy(
+        update={
+            "attempts": list(attempts),
+            "availability_state": "available_with_caveats" if caveated else "available",
+            "parent_eligible": parent_eligible,
+            "parent_eligibility_reason": parent_reason,
+            "validation_decisions": [
+                *retained,
+                *[
+                    VariationValidationDecision.model_validate(
+                        {
+                            "stage": stage,
+                            "disposition": disposition,
+                            "reason": reason,
+                        }
+                    )
+                    for stage, (disposition, reason) in replacements.items()
+                ],
+            ],
+        }
+    )
+    if updated != envelope:
+        manifest.run_configuration["variation_envelope"] = updated.model_dump(mode="json")
+        try:
+            write_run_manifest(manifest_path, manifest)
+        except OSError:
+            return envelope
+    return updated
+
+
+def _evaluate_variation_parent_eligibility(
+    manifest: RunManifest,
+    envelope: VariationEnvelope,
+    *,
+    accepted_backing: bool,
+) -> tuple[bool, str]:
+    if not accepted_backing:
+        return False, "Only the accepted backing attempt can parent a new variation."
+    if (
+        envelope.recipe_id != RECIPE_ID
+        or envelope.recipe_contract_version != RECIPE_CONTRACT_VERSION
+    ):
+        return False, "The retained Simulation is outside the current Trade Cumulus Recipe."
+    controls_payload = envelope.world_payload.get("controls")
+    try:
+        controls = TradeCumulusControls.model_validate(controls_payload)
+        normalized = normalize_controls(controls)
+    except ValueError:
+        return False, "The retained Simulation lacks valid absolute Recipe controls."
+    if controls != normalized:
+        return False, "The retained Simulation contains unresolved inactive controls."
+    provenance = manifest.run_configuration.get("cm1_provenance")
+    if not isinstance(provenance, Mapping) or not all(
+        isinstance(provenance.get(key), str) and provenance.get(key)
+        for key in ("source_manifest_sha256", "executable_sha256")
+    ):
+        return False, "Pinned CM1 source and executable identity are unavailable."
+    return True, "Accepted output remains reconstructible inside Recipe contract version 1."
+
+
+def _envelope_configuration_differences(
+    envelope: VariationEnvelope | None,
+) -> list[ConfigurationDifference] | None:
+    if envelope is None:
+        return None
+    category = {
+        "terrain": "atmospheric",
+        "wind": "atmospheric",
+        "moisture": "atmospheric",
+        "stability_thermodynamics": "atmospheric",
+        "forcing_initiation": "atmospheric",
+        "numerical_realization": "numerical",
+        "observation_plan": "output",
+    }
+    return [
+        ConfigurationDifference.model_validate(
+            {
+                "path": difference.path,
+                "label": difference.label,
+                "category": category[difference.category],
+                "left_value": difference.before,
+                "right_value": difference.after,
+                "units": difference.units,
+                "material": difference.material,
+            }
+        )
+        for difference in envelope.differences
+    ]
 
 
 def _lineage_candidate(metadata: ResultMetadata) -> _LineageCandidate:
@@ -1012,13 +1447,76 @@ def _trust_state(metadata: ResultMetadata) -> TrustState:
 
 
 def _is_trade_cumulus_result(metadata: ResultMetadata) -> bool:
-    return metadata.scenario_id == CASE_ID and _is_trade_cumulus_configuration(
-        metadata.run_configuration
-    )
+    return (
+        metadata.scenario_id == CASE_ID
+        or (
+            metadata.scenario_id == "trade_cumulus_recipe_variation_v1"
+            and metadata.run_configuration.get("cloud_world_id") == WORLD_ID
+        )
+    ) and _is_trade_cumulus_configuration(metadata.run_configuration)
 
 
 def _is_trade_cumulus_configuration(configuration: Mapping[str, object]) -> bool:
-    return configuration.get("case_id") == CASE_ID
+    return configuration.get("case_id") == CASE_ID or (
+        configuration.get("cloud_world_id") == WORLD_ID
+        and isinstance(configuration.get("variation_envelope"), Mapping)
+    )
+
+
+def _with_variation_eligibility(
+    settings: CloudChamberSettings,
+    record: SimulationRecord,
+) -> SimulationRecord:
+    if record.technical_state != "available" or not record.explore_available:
+        return record.model_copy(
+            update={
+                "can_create_variation": False,
+                "parent_eligibility_reason": (
+                    "Only an available, inspectable Simulation can parent a variation."
+                ),
+            }
+        )
+    if record.simulation_id in _RESERVED_SIMULATION_IDS:
+        return record.model_copy(
+            update={
+                "can_create_variation": True,
+                "parent_eligibility_reason": None,
+            }
+        )
+    manifest_path = (
+        settings.runtime_home.expanduser() / "runs" / record.run_id / "run_manifest.json"
+    )
+    try:
+        manifest = load_run_manifest(manifest_path)
+        payload = manifest.run_configuration.get("variation_envelope")
+        envelope = VariationEnvelope.model_validate(payload)
+    except (OSError, ValueError, RunManifestError):
+        return record.model_copy(
+            update={
+                "can_create_variation": False,
+                "parent_eligibility_reason": (
+                    "This Simulation predates the shared Recipe envelope."
+                ),
+            }
+        )
+    if envelope.world_id != WORLD_ID or envelope.recipe_id != "canonical_bomex_trade_cumulus":
+        return record.model_copy(
+            update={
+                "can_create_variation": False,
+                "parent_eligibility_reason": "The retained Recipe envelope does not match.",
+            }
+        )
+    return record.model_copy(
+        update={
+            "recipe_contract_version": envelope.recipe_contract_version,
+            "relationship_classification": envelope.relationship_classification,
+            "can_create_variation": envelope.parent_eligible,
+            "parent_eligibility_reason": (
+                None if envelope.parent_eligible else envelope.parent_eligibility_reason
+            ),
+            "attempt_count": len(envelope.attempts),
+        }
+    )
 
 
 def _comparison_payload(metadata: ResultMetadata) -> dict[str, Any]:
@@ -1033,6 +1531,19 @@ def _comparison_payload(metadata: ResultMetadata) -> dict[str, Any]:
         if key not in controls and key not in {"control_id", "control_state", "changed_assumptions"}
     }
     return {"controls": controls, "run_configuration": configuration}
+
+
+def _trade_configuration_summary(configuration: Mapping[str, object]) -> dict[str, Any]:
+    return {
+        key: configuration[key]
+        for key in (
+            "duration_seconds",
+            "output_cadence_seconds",
+            "expected_model_output_count",
+            "domain",
+        )
+        if key in configuration
+    }
 
 
 def _compare_values(

--- a/app/backend/cloud_chamber/cm1_source_customization.py
+++ b/app/backend/cloud_chamber/cm1_source_customization.py
@@ -12,6 +12,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, cast
 
 from cloud_chamber.run_manifest import RunManifest
 from cloud_chamber.settings import CloudChamberSettings
@@ -27,6 +28,14 @@ from cloud_chamber.surface_forcing import (
     CM1_SOURCE_CUSTOMIZATION_FILENAME,
     DIFFERENTIAL_SURFACE_FORCING_MODE,
     SURFACE_FORCING_PATCH_FILENAME,
+)
+from cloud_chamber.trade_cumulus_forcing import (
+    TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND,
+    TRADE_CUMULUS_FORCING_MARKER,
+    TRADE_CUMULUS_FORCING_TARGET,
+    TradeCumulusForcingError,
+    load_forcing_customization,
+    render_trade_cumulus_forcing_source,
 )
 
 CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
@@ -121,6 +130,20 @@ def prepare_cm1_source_customization(
             "hodograph_profile": customization["wind_profile"],
             "no_silent_hodograph_fallback": True,
         }
+    elif customization_kind == TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND:
+        customization = load_forcing_customization(customization_path)
+        target_relative_path = TRADE_CUMULUS_FORCING_TARGET
+        forcing = cast(dict[str, Any], customization["forcing"])
+
+        def patch_source(source: str) -> str:
+            return render_trade_cumulus_forcing_source(source, forcing)
+
+        expected_original_sha256 = str(customization["original_source_sha256"])
+        expected_patched_sha256 = str(customization["patched_source_sha256"])
+        status_details = {
+            "forcing": customization["forcing"],
+            "no_silent_forcing_fallback": True,
+        }
     else:
         raise CM1SourceCustomizationError(
             f"Unsupported CM1 source customization kind: {customization_kind}"
@@ -159,7 +182,7 @@ def prepare_cm1_source_customization(
             )
         try:
             patched_source = patch_source(original_source)
-        except StraightLineHodographError as exc:
+        except (StraightLineHodographError, TradeCumulusForcingError) as exc:
             raise CM1SourceCustomizationError(str(exc)) from exc
         patched_source_sha256 = _text_sha256(patched_source)
         if expected_patched_sha256 is not None and patched_source_sha256 != expected_patched_sha256:
@@ -348,6 +371,7 @@ def _fail_if_source_already_customized(cm1_root: Path) -> None:
     targets = (
         (SFCPHYS_TARGET, SFCPHYS_MARKER),
         (STRAIGHT_LINE_HODOGRAPH_TARGET, STRAIGHT_LINE_HODOGRAPH_MARKER),
+        (TRADE_CUMULUS_FORCING_TARGET, TRADE_CUMULUS_FORCING_MARKER),
     )
     for relative_path, marker in targets:
         path = cm1_root / relative_path

--- a/app/backend/cloud_chamber/lifecycle.py
+++ b/app/backend/cloud_chamber/lifecycle.py
@@ -6,7 +6,7 @@ import json
 from collections import defaultdict
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -1078,7 +1078,7 @@ def _variation_source(
     owner = _string(configuration.get("cloud_world_id"))
     simulation_id = _string(configuration.get("simulation_id"))
     display_name = _string(configuration.get("simulation_display_name"))
-    if not _is_current_mountain_waves_variation(
+    if not _is_current_world_variation(
         run,
         owner=owner,
         simulation_id=simulation_id,
@@ -1105,7 +1105,7 @@ def _variation_source(
     caveats = [*run.run_caveats, *(result.caveats if result is not None else [])]
     differences = _configuration_differences(configuration.get("configuration_difference"))
     return WorldLifecycleSource(
-        owner_id="mountain_waves",
+        owner_id=cast(WorldOwnerId, owner),
         simulation_id=simulation_id,
         display_name=display_name,
         role="variation",
@@ -1135,7 +1135,7 @@ def _variation_source(
     )
 
 
-def _is_current_mountain_waves_variation(
+def _is_current_world_variation(
     run: RunStorageEntry,
     *,
     owner: str | None,
@@ -1143,15 +1143,28 @@ def _is_current_mountain_waves_variation(
     display_name: str | None,
 ) -> bool:
     configuration = run.run_configuration or {}
+    if owner == "mountain_waves":
+        world_payload_valid = isinstance(configuration.get("mountain_waves_configuration"), dict)
+        case_valid = run.scenario_id in {VARIATION_CASE_ID, LEGACY_VARIATION_CASE_ID}
+        reference_valid = _string(configuration.get("reference_simulation_id")) in {
+            DRY_SIMULATION_ID,
+            MOIST_SIMULATION_ID,
+        }
+    elif owner == "trade_cumulus":
+        world_payload_valid = isinstance(configuration.get("trade_cumulus_configuration"), dict)
+        case_valid = run.scenario_id == "trade_cumulus_recipe_variation_v1"
+        reference_valid = (
+            _string(configuration.get("reference_simulation_id")) == REFERENCE_SIMULATION_ID
+        )
+    else:
+        return False
     return (
-        owner == "mountain_waves"
-        and run.scenario_id in {VARIATION_CASE_ID, LEGACY_VARIATION_CASE_ID}
+        case_valid
         and bool(simulation_id)
         and bool(display_name)
         and bool(_string(configuration.get("parent_simulation_id")))
-        and _string(configuration.get("reference_simulation_id"))
-        in {DRY_SIMULATION_ID, MOIST_SIMULATION_ID}
-        and isinstance(configuration.get("mountain_waves_configuration"), dict)
+        and reference_valid
+        and world_payload_valid
         and isinstance(configuration.get("configuration_difference"), dict)
         and bool(configuration.get("generated_input_sha256"))
         and isinstance(configuration.get("generated_input_sha256"), dict)

--- a/app/backend/cloud_chamber/local_run_manager.py
+++ b/app/backend/cloud_chamber/local_run_manager.py
@@ -6,6 +6,7 @@ Tests inject fake processes; CI never requires a real CM1 runtime.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import shutil
@@ -228,6 +229,7 @@ class LocalRunManager:
                 + str(exc)
             ) from exc
         command = [str(executable)]
+        executable_sha256 = _sha256_file(executable)
         log_dir = run_dir / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
         stdout_log = log_dir / "stdout.log"
@@ -238,6 +240,7 @@ class LocalRunManager:
             state=LifecycleState.QUEUED,
             product_state=ProductState.QUEUED_RUNNING_CM1_PROCESS,
             command=command,
+            executable_sha256=executable_sha256,
             stdout_log=stdout_log,
             stderr_log=stderr_log,
             cm1_source_customization_status=source_customization_status,
@@ -378,6 +381,7 @@ class LocalRunManager:
         state: LifecycleState,
         product_state: ProductState,
         command: list[str] | None = None,
+        executable_sha256: str | None = None,
         stdout_log: Path | None = None,
         stderr_log: Path | None = None,
         process_id: int | None = None,
@@ -409,6 +413,11 @@ class LocalRunManager:
         execution = existing_execution.model_copy(
             update={
                 "command": command or existing_execution.command,
+                "executable_sha256": (
+                    executable_sha256
+                    if executable_sha256 is not None
+                    else existing_execution.executable_sha256
+                ),
                 "process_id": (
                     process_id if process_id is not None else existing_execution.process_id
                 ),
@@ -440,6 +449,14 @@ class LocalRunManager:
                 "updated_at": now,
             }
         )
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _status_from_manifest(

--- a/app/backend/cloud_chamber/local_run_manager.py
+++ b/app/backend/cloud_chamber/local_run_manager.py
@@ -25,6 +25,11 @@ from cloud_chamber.generated_input_identity import (
     verify_generated_input_identity,
 )
 from cloud_chamber.pre_run_validation import report_blocks_execution
+from cloud_chamber.run_cost import (
+    ImmediatePrelaunchCheck,
+    LaunchBudgetError,
+    preflight_manifest_launch_budget,
+)
 from cloud_chamber.run_manifest import (
     ExecutionMetadata,
     LifecycleState,
@@ -76,6 +81,7 @@ class RunStatus:
     stdout_log: Path
     stderr_log: Path
     exit_code: int | None
+    launch_budget_preflight_check: ImmediatePrelaunchCheck | None = None
 
 
 @dataclass
@@ -208,6 +214,19 @@ class LocalRunManager:
             if source_customization is not None
             else None
         )
+        snapshot_value = manifest.run_configuration.get("launch_review_snapshot_id")
+        snapshot_id = snapshot_value if isinstance(snapshot_value, str) else None
+        try:
+            launch_budget_preflight_check = preflight_manifest_launch_budget(
+                self._settings,
+                manifest=manifest,
+                snapshot_id=snapshot_id,
+            )
+        except LaunchBudgetError as exc:
+            raise LocalRunManagerError(
+                "Final disk gate failed after source staging and before CM1 process creation: "
+                + str(exc)
+            ) from exc
         command = [str(executable)]
         log_dir = run_dir / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
@@ -262,7 +281,11 @@ class LocalRunManager:
                         "CM1 started, but neither process cleanup nor durable Running-state "
                         f"tracking succeeded: {tracking_exc}"
                     ) from exc
-                return _status_from_manifest(running, manifest_path)
+                return _status_from_manifest(
+                    running,
+                    manifest_path,
+                    launch_budget_preflight_check=launch_budget_preflight_check,
+                )
             self._close_active()
             try:
                 write_run_manifest(manifest_path, manifest)
@@ -275,7 +298,11 @@ class LocalRunManager:
                 "CM1 started, but durable Running-state tracking failed; the process was "
                 "terminated and the package remains retryable."
             ) from exc
-        return _status_from_manifest(running, manifest_path)
+        return _status_from_manifest(
+            running,
+            manifest_path,
+            launch_budget_preflight_check=launch_budget_preflight_check,
+        )
 
     def status(self, manifest_path: Path) -> RunStatus:
         self._refresh_active()
@@ -415,7 +442,12 @@ class LocalRunManager:
         )
 
 
-def _status_from_manifest(manifest: RunManifest, manifest_path: Path) -> RunStatus:
+def _status_from_manifest(
+    manifest: RunManifest,
+    manifest_path: Path,
+    *,
+    launch_budget_preflight_check: ImmediatePrelaunchCheck | None = None,
+) -> RunStatus:
     stdout_log = Path(manifest.execution.stdout_log or "")
     stderr_log = Path(manifest.execution.stderr_log or "")
     return RunStatus(
@@ -426,6 +458,7 @@ def _status_from_manifest(manifest: RunManifest, manifest_path: Path) -> RunStat
         stdout_log=stdout_log,
         stderr_log=stderr_log,
         exit_code=manifest.execution.exit_code,
+        launch_budget_preflight_check=launch_budget_preflight_check,
     )
 
 

--- a/app/backend/cloud_chamber/local_run_queue.py
+++ b/app/backend/cloud_chamber/local_run_queue.py
@@ -217,6 +217,7 @@ class LocalRunQueueManager:
                 snapshot_id=snapshot_id,
             )
             status = self._run_manager.launch(Path(entry.manifest_path))
+            preflight_check = status.launch_budget_preflight_check or preflight_check
         except (LaunchBudgetError, LocalRunManagerError, OSError, RunManifestError) as exc:
             now = _now()
             entry.state = "launch_failed"

--- a/app/backend/cloud_chamber/run_cost.py
+++ b/app/backend/cloud_chamber/run_cost.py
@@ -1054,6 +1054,7 @@ def _profile(
         observation_plan=ObservationPlan(
             duration_seconds=duration,
             output_cadence_seconds=cadence,
+            diagnostic_cadence_seconds=60 if world_id == "trade_cumulus" else None,
             expected_history_count=histories,
             retained_field_inventory=_retained_field_inventory(world_id, recipe_id),
         ),

--- a/app/backend/cloud_chamber/run_cost.py
+++ b/app/backend/cloud_chamber/run_cost.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import os
 import shutil
 from datetime import UTC, datetime
@@ -11,7 +12,7 @@ from pathlib import Path
 from typing import Literal
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from cloud_chamber.run_manifest import RunManifest
 from cloud_chamber.settings import CloudChamberSettings
@@ -29,6 +30,7 @@ TRADE_CUMULUS_RETAINED_FIELDS = (
     "qv",
     "th",
     "prs",
+    "rho",
     "u",
     "v",
     "w",
@@ -95,6 +97,49 @@ class NumericalRealization(BaseModel):
     spacing: str
     timestep_strategy: str
     physics_source: str
+    exact_domain: ExactNumericalDomain | None = None
+
+
+class ExactNumericalDomain(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    nx: int = Field(gt=0)
+    ny: int = Field(gt=0)
+    nz: int = Field(gt=0)
+    dx_m: float = Field(gt=0)
+    dy_m: float = Field(gt=0)
+    dz_m: float = Field(gt=0)
+    x_extent_m: float = Field(gt=0)
+    y_extent_m: float = Field(gt=0)
+    model_top_m: float = Field(gt=0)
+    x_min_m: float
+    x_max_m: float
+    y_min_m: float
+    y_max_m: float
+    timestep_seconds: float = Field(gt=0)
+
+    @model_validator(mode="after")
+    def validate_geometry(self) -> ExactNumericalDomain:
+        expected = {
+            "x_extent_m": self.nx * self.dx_m,
+            "y_extent_m": self.ny * self.dy_m,
+            "model_top_m": self.nz * self.dz_m,
+            "x_bounds": self.x_max_m - self.x_min_m,
+            "y_bounds": self.y_max_m - self.y_min_m,
+        }
+        actual = {
+            "x_extent_m": self.x_extent_m,
+            "y_extent_m": self.y_extent_m,
+            "model_top_m": self.model_top_m,
+            "x_bounds": self.x_extent_m,
+            "y_bounds": self.y_extent_m,
+        }
+        if any(
+            not math.isclose(actual[key], value, rel_tol=0.0, abs_tol=1.0e-6)
+            for key, value in expected.items()
+        ):
+            raise ValueError("Exact numerical domain geometry is internally inconsistent.")
+        return self
 
 
 class ObservationPlan(BaseModel):
@@ -659,6 +704,7 @@ def profiles() -> list[RunCostProfile]:
             basis="scaled_from_measured",
             confidence="Scaled from measured six-hour lower-resolution runs.",
             limitation="Early response; not a full steady-period assessment.",
+            exact_domain=_exact_domain(64, 64, 75, 100.0, 100.0, 40.0, 3.0),
         ),
         _profile(
             world_id="trade_cumulus",
@@ -677,6 +723,7 @@ def profiles() -> list[RunCostProfile]:
             size=(int(1.6 * GIB), int(2.2 * GIB)),
             basis="scaled_from_measured",
             confidence="Scaled from measured lower-resolution runs.",
+            exact_domain=_exact_domain(64, 64, 75, 100.0, 100.0, 40.0, 3.0),
         ),
         _profile(
             world_id="trade_cumulus",
@@ -695,6 +742,7 @@ def profiles() -> list[RunCostProfile]:
             size=(int(2.5 * GIB), int(3.2 * GIB)),
             basis="measured",
             confidence="Measured near the Baseline and More Moisture reference runs.",
+            exact_domain=_exact_domain(64, 64, 75, 100.0, 100.0, 40.0, 3.0),
         ),
         _profile(
             world_id="trade_cumulus",
@@ -713,6 +761,15 @@ def profiles() -> list[RunCostProfile]:
             size=(int(9.08 * GIB), int(9.34 * GIB)),
             basis="measured",
             confidence="Measured retained presentation runs.",
+            exact_domain=_exact_domain(
+                96,
+                96,
+                100,
+                66.66666667,
+                66.66666667,
+                30.0,
+                2.0,
+            ),
         ),
         _profile(
             world_id="trade_cumulus",
@@ -732,6 +789,7 @@ def profiles() -> list[RunCostProfile]:
             basis="uncharacterized",
             confidence="Requires bounded characterization before launch.",
             limitation="Not an ordinary default.",
+            exact_domain=_exact_domain(128, 128, 75, 100.0, 100.0, 40.0, 3.0),
         ),
         _profile(
             world_id="mountain_waves",
@@ -975,6 +1033,7 @@ def _profile(
     basis: EstimateBasis,
     confidence: str,
     limitation: str | None = None,
+    exact_domain: ExactNumericalDomain | None = None,
 ) -> RunCostProfile:
     return RunCostProfile(
         world_id=world_id,
@@ -990,6 +1049,7 @@ def _profile(
             spacing=spacing,
             timestep_strategy=timestep,
             physics_source="Approved World Recipe",
+            exact_domain=exact_domain,
         ),
         observation_plan=ObservationPlan(
             duration_seconds=duration,
@@ -1008,6 +1068,35 @@ def _profile(
             "compression may change actual cost."
         ],
         scientific_limitations=[limitation] if limitation else [],
+    )
+
+
+def _exact_domain(
+    nx: int,
+    ny: int,
+    nz: int,
+    dx_m: float,
+    dy_m: float,
+    dz_m: float,
+    timestep_seconds: float,
+) -> ExactNumericalDomain:
+    x_extent_m = nx * dx_m
+    y_extent_m = ny * dy_m
+    return ExactNumericalDomain(
+        nx=nx,
+        ny=ny,
+        nz=nz,
+        dx_m=dx_m,
+        dy_m=dy_m,
+        dz_m=dz_m,
+        x_extent_m=x_extent_m,
+        y_extent_m=y_extent_m,
+        model_top_m=nz * dz_m,
+        x_min_m=-0.5 * x_extent_m,
+        x_max_m=0.5 * x_extent_m,
+        y_min_m=-0.5 * y_extent_m,
+        y_max_m=0.5 * y_extent_m,
+        timestep_seconds=timestep_seconds,
     )
 
 

--- a/app/backend/cloud_chamber/run_manifest.py
+++ b/app/backend/cloud_chamber/run_manifest.py
@@ -90,6 +90,7 @@ class ExecutionMetadata(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     command: list[str] = Field(default_factory=list)
+    executable_sha256: str | None = None
     process_id: int | None = None
     started_at: datetime | None = None
     finished_at: datetime | None = None

--- a/app/backend/cloud_chamber/trade_cumulus_attempt_provenance.py
+++ b/app/backend/cloud_chamber/trade_cumulus_attempt_provenance.py
@@ -1,0 +1,254 @@
+"""Strict provenance binding for retained Trade Cumulus variation attempts."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from cloud_chamber.bomex_case import (
+    CM1_EXECUTABLE_SHA256,
+    CM1_SOURCE_MANIFEST_SHA256,
+    CRITICAL_SOURCE_HASHES,
+)
+from cloud_chamber.run_manifest import RunManifest
+from cloud_chamber.trade_cumulus_forcing import (
+    TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND,
+    TRADE_CUMULUS_FORCING_TARGET,
+    load_forcing_customization,
+)
+from cloud_chamber.trade_cumulus_recipes import (
+    TradeCumulusControls,
+    default_controls,
+    normalize_controls,
+)
+from cloud_chamber.variation_envelope import VariationEnvelope
+
+
+class TradeCumulusAttemptProvenanceError(ValueError):
+    """Raised when a retained attempt is not bound to approved CM1 provenance."""
+
+
+def validate_trade_cumulus_attempt_provenance(
+    manifest: RunManifest,
+) -> dict[str, Any]:
+    """Bind the reviewed package to approved source and the executable actually used."""
+    provenance = manifest.run_configuration.get("cm1_provenance")
+    if not isinstance(provenance, Mapping):
+        raise TradeCumulusAttemptProvenanceError("Pinned CM1 provenance is unavailable.")
+    if provenance.get("source_manifest_sha256") != CM1_SOURCE_MANIFEST_SHA256:
+        raise TradeCumulusAttemptProvenanceError(
+            "CM1 source identity does not match the approved source manifest."
+        )
+    if provenance.get("executable_sha256") != CM1_EXECUTABLE_SHA256:
+        raise TradeCumulusAttemptProvenanceError(
+            "CM1 executable identity does not match the approved canonical executable."
+        )
+
+    controls = _retained_controls(manifest)
+    forcing_required = _forcing_changed(controls)
+    declared_kind = manifest.run_configuration.get("cm1_source_customization_kind")
+    customization_path_value = manifest.generated_inputs.cm1_source_customization
+    status = manifest.cm1_source_customization_status
+
+    if not forcing_required:
+        if declared_kind is not None or customization_path_value is not None or status is not None:
+            raise TradeCumulusAttemptProvenanceError(
+                "Canonical forcing attempt carries contradictory source-customization evidence."
+            )
+        return {
+            "approved_source_manifest_sha256": CM1_SOURCE_MANIFEST_SHA256,
+            "executable_kind": "approved_canonical",
+            "executable_sha256": CM1_EXECUTABLE_SHA256,
+            "forcing_customization_required": False,
+        }
+
+    if declared_kind != TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND:
+        raise TradeCumulusAttemptProvenanceError(
+            "Forcing-modified attempt lacks the declared Trade Cumulus customization kind."
+        )
+    if not customization_path_value:
+        raise TradeCumulusAttemptProvenanceError(
+            "Forcing-modified attempt lacks its packaged source customization."
+        )
+    run_dir = Path(manifest.generated_inputs.run_directory).expanduser().resolve()
+    customization_path = Path(customization_path_value).expanduser().resolve()
+    _require_contained(customization_path, run_dir, "Packaged source customization")
+    try:
+        customization = load_forcing_customization(customization_path)
+    except (OSError, ValueError) as exc:
+        raise TradeCumulusAttemptProvenanceError(
+            "Packaged Trade Cumulus forcing customization is invalid."
+        ) from exc
+    if (
+        customization.get("original_source_sha256")
+        != CRITICAL_SOURCE_HASHES[str(TRADE_CUMULUS_FORCING_TARGET)]
+    ):
+        raise TradeCumulusAttemptProvenanceError(
+            "Packaged forcing customization does not start from the approved base.F."
+        )
+    expected_forcing = {
+        "vertical_motion_m_s": controls.large_scale_vertical_motion_m_s,
+        "temperature_tendency_k_day": controls.temperature_tendency_k_day,
+        "total_water_tendency_g_kg_day": controls.total_water_tendency_g_kg_day,
+    }
+    _require_numeric_mapping(
+        customization.get("forcing"),
+        expected_forcing,
+        "Packaged forcing targets",
+    )
+
+    if not isinstance(status, Mapping):
+        raise TradeCumulusAttemptProvenanceError(
+            "Forcing-modified attempt lacks applied-build status."
+        )
+    required_status = {
+        "schema_version": "cm1_source_customization_status_v1",
+        "customization_kind": TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND,
+        "run_id": manifest.run_id,
+        "original_target_sha256": customization["original_source_sha256"],
+        "patched_target_sha256": customization["patched_source_sha256"],
+        "source_restored_after_build": "not_modified_isolated_build_tree",
+    }
+    mismatches = {
+        key: (status.get(key), expected)
+        for key, expected in required_status.items()
+        if status.get(key) != expected
+    }
+    if mismatches:
+        raise TradeCumulusAttemptProvenanceError(
+            f"Applied forcing customization disagrees with the package: {mismatches}."
+        )
+    if status.get("patched_files") != [str(TRADE_CUMULUS_FORCING_TARGET)]:
+        raise TradeCumulusAttemptProvenanceError(
+            "Applied forcing customization has an unexpected patched-file inventory."
+        )
+    if status.get("build_command") != ["make"]:
+        raise TradeCumulusAttemptProvenanceError(
+            "Applied forcing customization lacks the isolated CM1 build record."
+        )
+    if status.get("no_silent_forcing_fallback") is not True:
+        raise TradeCumulusAttemptProvenanceError(
+            "Applied forcing customization permits an unreviewed fallback."
+        )
+    _require_numeric_mapping(status.get("forcing"), expected_forcing, "Applied forcing readback")
+
+    status_customization = _required_status_path(status, "customization_manifest")
+    if status_customization != customization_path:
+        raise TradeCumulusAttemptProvenanceError(
+            "Applied build status references a different forcing customization."
+        )
+    build_root = _required_status_path(status, "build_root")
+    runtime_builds = (
+        Path(manifest.runtime_paths.runtime_home).expanduser().resolve() / "cm1_source_builds"
+    )
+    _require_contained(build_root, runtime_builds, "Isolated CM1 build")
+    if not build_root.is_dir():
+        raise TradeCumulusAttemptProvenanceError(
+            "Applied forcing customization build tree is unavailable."
+        )
+
+    executable_path = _required_status_path(status, "custom_executable")
+    _require_contained(executable_path, run_dir, "Custom CM1 executable")
+    if not executable_path.is_file():
+        raise TradeCumulusAttemptProvenanceError("Applied custom CM1 executable is unavailable.")
+    executable_sha256 = status.get("custom_executable_sha256")
+    if not isinstance(executable_sha256, str) or _sha256_file(executable_path) != executable_sha256:
+        raise TradeCumulusAttemptProvenanceError(
+            "Applied custom CM1 executable hash does not match the retained executable."
+        )
+    if (
+        not manifest.execution.command
+        or Path(manifest.execution.command[0]).expanduser().resolve() != executable_path
+    ):
+        raise TradeCumulusAttemptProvenanceError(
+            "Retained CM1 execution did not use the applied custom executable."
+        )
+
+    return {
+        "approved_source_manifest_sha256": CM1_SOURCE_MANIFEST_SHA256,
+        "executable_kind": "isolated_forcing_customization",
+        "executable_sha256": executable_sha256,
+        "forcing_customization_required": True,
+        "customization_kind": TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND,
+        "original_target_sha256": customization["original_source_sha256"],
+        "patched_target_sha256": customization["patched_source_sha256"],
+        "forcing_readback": expected_forcing,
+    }
+
+
+def _retained_controls(manifest: RunManifest) -> TradeCumulusControls:
+    try:
+        envelope = VariationEnvelope.model_validate(
+            manifest.run_configuration.get("variation_envelope")
+        )
+        return normalize_controls(
+            TradeCumulusControls.model_validate(envelope.world_payload.get("controls"))
+        )
+    except ValueError as exc:
+        raise TradeCumulusAttemptProvenanceError(
+            "Retained attempt lacks valid absolute Trade Cumulus controls."
+        ) from exc
+
+
+def _forcing_changed(controls: TradeCumulusControls) -> bool:
+    reference = default_controls()
+    return any(
+        not math.isclose(
+            getattr(controls, field),
+            getattr(reference, field),
+            rel_tol=0.0,
+            abs_tol=1.0e-12,
+        )
+        for field in (
+            "large_scale_vertical_motion_m_s",
+            "temperature_tendency_k_day",
+            "total_water_tendency_g_kg_day",
+        )
+    )
+
+
+def _require_numeric_mapping(
+    value: object,
+    expected: dict[str, float],
+    label: str,
+) -> None:
+    if not isinstance(value, Mapping) or set(value) != set(expected):
+        raise TradeCumulusAttemptProvenanceError(f"{label} is missing or incomplete.")
+    if any(
+        not isinstance(value[key], int | float)
+        or not math.isclose(
+            float(value[key]),
+            target,
+            rel_tol=0.0,
+            abs_tol=1.0e-12,
+        )
+        for key, target in expected.items()
+    ):
+        raise TradeCumulusAttemptProvenanceError(
+            f"{label} does not match the reviewed forcing targets."
+        )
+
+
+def _required_status_path(status: Mapping[str, object], key: str) -> Path:
+    value = status.get(key)
+    if not isinstance(value, str) or not value:
+        raise TradeCumulusAttemptProvenanceError(
+            f"Applied source-customization status lacks {key}."
+        )
+    return Path(value).expanduser().resolve()
+
+
+def _require_contained(path: Path, root: Path, label: str) -> None:
+    if not path.is_relative_to(root):
+        raise TradeCumulusAttemptProvenanceError(f"{label} escapes its accepted attempt storage.")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/app/backend/cloud_chamber/trade_cumulus_attempt_provenance.py
+++ b/app/backend/cloud_chamber/trade_cumulus_attempt_provenance.py
@@ -58,10 +58,34 @@ def validate_trade_cumulus_attempt_provenance(
             raise TradeCumulusAttemptProvenanceError(
                 "Canonical forcing attempt carries contradictory source-customization evidence."
             )
+        command_path = _execution_path(manifest)
+        configured_run_dir = manifest.runtime_paths.cm1_run_dir
+        if not configured_run_dir:
+            raise TradeCumulusAttemptProvenanceError(
+                "Canonical CM1 execution lacks its configured run directory."
+            )
+        expected_path = Path(configured_run_dir).expanduser().resolve() / "cm1.exe"
+        if command_path != expected_path:
+            raise TradeCumulusAttemptProvenanceError(
+                "Retained CM1 execution did not use the approved configured executable."
+            )
+        if not command_path.is_file():
+            raise TradeCumulusAttemptProvenanceError(
+                "The approved configured CM1 executable is unavailable."
+            )
+        actual_sha256 = _sha256_file(command_path)
+        if (
+            manifest.execution.executable_sha256 != CM1_EXECUTABLE_SHA256
+            or actual_sha256 != CM1_EXECUTABLE_SHA256
+        ):
+            raise TradeCumulusAttemptProvenanceError(
+                "Retained canonical CM1 executable identity does not match the executable used."
+            )
         return {
             "approved_source_manifest_sha256": CM1_SOURCE_MANIFEST_SHA256,
             "executable_kind": "approved_canonical",
             "executable_sha256": CM1_EXECUTABLE_SHA256,
+            "executable_path": str(command_path),
             "forcing_customization_required": False,
         }
 
@@ -159,12 +183,13 @@ def validate_trade_cumulus_attempt_provenance(
         raise TradeCumulusAttemptProvenanceError(
             "Applied custom CM1 executable hash does not match the retained executable."
         )
-    if (
-        not manifest.execution.command
-        or Path(manifest.execution.command[0]).expanduser().resolve() != executable_path
-    ):
+    if _execution_path(manifest) != executable_path:
         raise TradeCumulusAttemptProvenanceError(
             "Retained CM1 execution did not use the applied custom executable."
+        )
+    if manifest.execution.executable_sha256 != executable_sha256:
+        raise TradeCumulusAttemptProvenanceError(
+            "Retained launch-time executable hash does not match the applied custom executable."
         )
 
     return {
@@ -239,6 +264,12 @@ def _required_status_path(status: Mapping[str, object], key: str) -> Path:
             f"Applied source-customization status lacks {key}."
         )
     return Path(value).expanduser().resolve()
+
+
+def _execution_path(manifest: RunManifest) -> Path:
+    if not manifest.execution.command or not manifest.execution.command[0]:
+        raise TradeCumulusAttemptProvenanceError("Retained CM1 execution command is unavailable.")
+    return Path(manifest.execution.command[0]).expanduser().resolve()
 
 
 def _require_contained(path: Path, root: Path, label: str) -> None:

--- a/app/backend/cloud_chamber/trade_cumulus_forcing.py
+++ b/app/backend/cloud_chamber/trade_cumulus_forcing.py
@@ -1,0 +1,147 @@
+"""Source-locked CM1 forcing customization for Trade Cumulus variations."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND = "trade_cumulus_forcing_v1"
+TRADE_CUMULUS_FORCING_SCHEMA_VERSION = "trade_cumulus_forcing_customization_v1"
+TRADE_CUMULUS_FORCING_ARTIFACT_FILENAME = "trade_cumulus_forcing_customization.json"
+TRADE_CUMULUS_FORCING_TARGET = Path("src/base.F")
+TRADE_CUMULUS_FORCING_MARKER = "CLOUD_CHAMBER_TRADE_CUMULUS_FORCING_V1"
+
+
+class TradeCumulusForcingError(ValueError):
+    """Raised when the pinned BOMEX forcing block cannot be customized exactly."""
+
+
+def forcing_customization_artifact(
+    original_source: str,
+    *,
+    vertical_motion_m_s: float,
+    temperature_tendency_k_day: float,
+    total_water_tendency_g_kg_day: float,
+) -> dict[str, Any]:
+    forcing = {
+        "vertical_motion_m_s": vertical_motion_m_s,
+        "temperature_tendency_k_day": temperature_tendency_k_day,
+        "total_water_tendency_g_kg_day": total_water_tendency_g_kg_day,
+    }
+    rendered = render_trade_cumulus_forcing_source(original_source, forcing)
+    return {
+        "schema_version": TRADE_CUMULUS_FORCING_SCHEMA_VERSION,
+        "customization_kind": TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND,
+        "target": str(TRADE_CUMULUS_FORCING_TARGET),
+        "original_source_sha256": _sha256_text(original_source),
+        "patched_source_sha256": _sha256_text(rendered),
+        "forcing": forcing,
+        "profile_shape": {
+            "vertical_motion": "zero_to_peak_at_1500m_tapering_to_zero_at_2100m",
+            "temperature_tendency": "peak_through_1500m_tapering_to_zero_at_2100m",
+            "total_water_tendency": "peak_through_300m_tapering_to_zero_at_500m",
+        },
+    }
+
+
+def load_forcing_customization(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise TradeCumulusForcingError(
+            "Trade Cumulus forcing customization could not be read."
+        ) from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") != TRADE_CUMULUS_FORCING_SCHEMA_VERSION
+        or payload.get("customization_kind") != TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND
+        or payload.get("target") != str(TRADE_CUMULUS_FORCING_TARGET)
+        or not isinstance(payload.get("forcing"), dict)
+    ):
+        raise TradeCumulusForcingError("Trade Cumulus forcing customization is invalid.")
+    forcing = payload["forcing"]
+    required = {
+        "vertical_motion_m_s",
+        "temperature_tendency_k_day",
+        "total_water_tendency_g_kg_day",
+    }
+    if set(forcing) != required or any(
+        not isinstance(forcing[key], int | float) for key in required
+    ):
+        raise TradeCumulusForcingError("Trade Cumulus forcing values are invalid.")
+    return payload
+
+
+def render_trade_cumulus_forcing_source(
+    source: str,
+    forcing: dict[str, Any],
+) -> str:
+    if TRADE_CUMULUS_FORCING_MARKER in source:
+        raise TradeCumulusForcingError("CM1 source already contains the Trade Cumulus patch.")
+    start = source.find("    IF( testcase .eq. 3 )THEN")
+    end = source.find("    IF( testcase .eq. 4 )THEN", start)
+    if start < 0 or end < 0:
+        raise TradeCumulusForcingError("Unable to locate the pinned BOMEX forcing block.")
+    block = source[start:end]
+    replacements = (
+        (
+            r"(?m)^(\s*)wmin\s*=\s*-0\.0065\s*$",
+            rf"\1wmin  =  {_fortran(float(forcing['vertical_motion_m_s']))}",
+        ),
+        (
+            r"(?m)^(\s*)radsfc\s*=\s*-2\.0\s*/\(\s*3600\.0\s*\*\s*24\.0\s*\)\s*$",
+            rf"\1radsfc = {_fortran(float(forcing['temperature_tendency_k_day']) / 86_400.0)}",
+        ),
+        (
+            r"(?m)^(\s*)qvsfc\s*=\s*-1\.2e-8\s*$",
+            (
+                rf"\1qvsfc  = "
+                f"{_fortran(float(forcing['total_water_tendency_g_kg_day']) / 86_400_000.0)}"
+            ),
+        ),
+        (
+            r"(?m)^(\s*)qvfrc\(k\)\s*=\s*-1\.2e-8\s*$",
+            r"\1qvfrc(k) = qvsfc",
+        ),
+    )
+    rendered = block
+    for pattern, replacement in replacements:
+        rendered, count = re.subn(pattern, replacement, rendered, count=1)
+        if count != 1:
+            raise TradeCumulusForcingError(
+                "Pinned BOMEX forcing source no longer matches the approved patch."
+            )
+    marker = f"      ! {TRADE_CUMULUS_FORCING_MARKER}\n"
+    rendered = rendered.replace(
+        "      ! shallow Cu case  (Siebesma et al, 2003, JAS)\n",
+        "      ! shallow Cu case  (Siebesma et al, 2003, JAS)\n" + marker,
+        1,
+    )
+    return source[:start] + rendered + source[end:]
+
+
+def verify_forcing_artifact(path: Path, source: str) -> dict[str, Any]:
+    payload = load_forcing_customization(path)
+    if payload["original_source_sha256"] != _sha256_text(source):
+        raise TradeCumulusForcingError(
+            "Configured CM1 source does not match the packaged Trade Cumulus source lock."
+        )
+    rendered = render_trade_cumulus_forcing_source(source, payload["forcing"])
+    if payload["patched_source_sha256"] != _sha256_text(rendered):
+        raise TradeCumulusForcingError(
+            "Trade Cumulus forcing customization identity does not match its rendered source."
+        )
+    return payload
+
+
+def _fortran(value: float) -> str:
+    if value == 0.0:
+        return "0.0"
+    return f"{value:.12e}".replace("e", "d")
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()

--- a/app/backend/cloud_chamber/trade_cumulus_forcing_diagnostics.py
+++ b/app/backend/cloud_chamber/trade_cumulus_forcing_diagnostics.py
@@ -1,0 +1,88 @@
+"""Retained CM1 diagnostic contract for Trade Cumulus large-scale forcing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from cloud_chamber.run_cost import ExactNumericalDomain
+from cloud_chamber.trade_cumulus_recipes import TradeCumulusControls
+
+FORCING_DIAGNOSTIC_SCHEMA_VERSION = "trade_cumulus_forcing_diagnostics_v1"
+FORCING_DIAGNOSTIC_CADENCE_SECONDS = 60
+FORCING_DIAGNOSTIC_PATTERN = "cm1out_diag_*.nc"
+FORCING_DIAGNOSTIC_FIELDS = {
+    "wprof": {
+        "dimensions": ["time", "zf", "yh", "xh"],
+        "units": "m/s",
+        "meaning": "retained large-scale vertical-motion profile",
+    },
+    "ptb_frc": {
+        "dimensions": ["time", "zh", "yh", "xh"],
+        "units": "K/s",
+        "meaning": "retained large-scale potential-temperature tendency",
+    },
+    "qvb_frc": {
+        "dimensions": ["time", "zh", "yh", "xh"],
+        "units": "g/g/s",
+        "meaning": "retained large-scale total-water tendency",
+    },
+}
+
+
+def forcing_diagnostic_contract(
+    *,
+    duration_seconds: int,
+    numerical: ExactNumericalDomain,
+) -> dict[str, Any]:
+    if duration_seconds % FORCING_DIAGNOSTIC_CADENCE_SECONDS:
+        raise ValueError("Trade Cumulus duration must align with the forcing diagnostic cadence.")
+    return {
+        "schema_version": FORCING_DIAGNOSTIC_SCHEMA_VERSION,
+        "file_pattern": FORCING_DIAGNOSTIC_PATTERN,
+        "cadence_seconds": FORCING_DIAGNOSTIC_CADENCE_SECONDS,
+        "expected_file_count": (duration_seconds // FORCING_DIAGNOSTIC_CADENCE_SECONDS + 1),
+        "first_time_seconds": 0,
+        "last_time_seconds": duration_seconds,
+        "fields": FORCING_DIAGNOSTIC_FIELDS,
+        "vertical_grid": {
+            "zh_count": numerical.nz,
+            "zf_count": numerical.nz + 1,
+            "spacing_m": numerical.dz_m,
+            "model_top_m": numerical.model_top_m,
+        },
+        "profile_definition": {
+            "wprof": "linear_to_peak_at_1500_m_taper_to_zero_at_2100_m",
+            "ptb_frc": "constant_to_1500_m_taper_to_zero_at_2100_m",
+            "qvb_frc": "constant_to_300_m_taper_to_zero_at_500_m",
+        },
+    }
+
+
+def expected_forcing_profiles(
+    controls: TradeCumulusControls,
+    *,
+    zh_m: np.ndarray,
+    zf_m: np.ndarray,
+) -> dict[str, np.ndarray]:
+    w_factor = np.where(
+        zf_m <= 1_500.0,
+        zf_m / 1_500.0,
+        np.where(zf_m <= 2_100.0, (2_100.0 - zf_m) / 600.0, 0.0),
+    )
+    temperature_factor = np.where(
+        zh_m <= 1_500.0,
+        1.0,
+        np.where(zh_m <= 2_100.0, (2_100.0 - zh_m) / 600.0, 0.0),
+    )
+    water_factor = np.where(
+        zh_m <= 300.0,
+        1.0,
+        np.where(zh_m <= 500.0, (500.0 - zh_m) / 200.0, 0.0),
+    )
+    return {
+        "wprof": controls.large_scale_vertical_motion_m_s * w_factor,
+        "ptb_frc": controls.temperature_tendency_k_day / 86_400.0 * temperature_factor,
+        "qvb_frc": (controls.total_water_tendency_g_kg_day / 86_400_000.0 * water_factor),
+    }

--- a/app/backend/cloud_chamber/trade_cumulus_output_validation.py
+++ b/app/backend/cloud_chamber/trade_cumulus_output_validation.py
@@ -15,8 +15,14 @@ from cloud_chamber.generated_input_identity import (
     verify_generated_input_identity,
 )
 from cloud_chamber.result_ingest import ResultMetadata
+from cloud_chamber.run_cost import ExactNumericalDomain
 from cloud_chamber.run_manifest import LifecycleState, RunManifest
-from cloud_chamber.variation_envelope import VariationEnvelope
+from cloud_chamber.trade_cumulus_attempt_provenance import (
+    TradeCumulusAttemptProvenanceError,
+    validate_trade_cumulus_attempt_provenance,
+)
+from cloud_chamber.trade_cumulus_recipes import TradeCumulusControls, normalize_controls
+from cloud_chamber.variation_envelope import VariationEnvelope, canonical_payload_sha256
 
 
 class TradeCumulusOutputValidationError(ValueError):
@@ -31,6 +37,9 @@ _REQUIRED_UNITS = {
     "qv": ("kg kg-1", "kg/kg", "kg kg^-1"),
     "th": ("k",),
     "prs": ("pa",),
+    "rho": ("kg m-3", "kg/m3", "kg/m^3", "kg m^-3"),
+    "hfx": ("w m-2", "w/m2", "w/m^2", "w m^-2"),
+    "qfx": ("kg m-2 s-1", "kg/m2/s", "kg/m^2/s", "kg m^-2 s^-1"),
     "u": ("m s-1", "m/s", "m s^-1"),
     "v": ("m s-1", "m/s", "m s^-1"),
     "w": ("m s-1", "m/s", "m s^-1"),
@@ -54,6 +63,7 @@ def validate_trade_cumulus_variation_outputs(
         metadata.updated_at.isoformat(),
         tuple(_path_fingerprint(path) for path in paths),
         tuple(_generated_input_fingerprints(manifest)),
+        canonical_payload_sha256(manifest.cm1_source_customization_status),
     )
     cached = _VALIDATION_CACHE.get(key)
     if cached is not None:
@@ -98,7 +108,14 @@ def _validate_uncached(
         ) from exc
 
     envelope = _variation_envelope(manifest)
+    numerical = _exact_numerical_domain(envelope)
+    controls = _retained_controls(envelope)
+    try:
+        provenance_report = validate_trade_cumulus_attempt_provenance(manifest)
+    except TradeCumulusAttemptProvenanceError as exc:
+        raise TradeCumulusOutputValidationError(str(exc)) from exc
     observation = envelope.observation_plan.payload
+    expected_duration = observation.get("duration_seconds")
     expected_count = observation.get("expected_history_count")
     expected_cadence = observation.get("output_cadence_seconds")
     expected_fields = observation.get("retained_field_inventory")
@@ -109,6 +126,23 @@ def _validate_uncached(
     if not isinstance(expected_cadence, int | float) or expected_cadence <= 0:
         raise TradeCumulusOutputValidationError(
             "The retained envelope lacks an exact output cadence."
+        )
+    if not isinstance(expected_duration, int | float) or expected_duration < 0:
+        raise TradeCumulusOutputValidationError(
+            "The retained envelope lacks an exact modeled duration."
+        )
+    expected_times = [float(index) * float(expected_cadence) for index in range(expected_count)]
+    if (
+        not math.isclose(
+            expected_times[-1],
+            float(expected_duration),
+            rel_tol=0.0,
+            abs_tol=_TIME_TOLERANCE_SECONDS,
+        )
+        or len(expected_times) != expected_count
+    ):
+        raise TradeCumulusOutputValidationError(
+            "The reviewed duration, cadence, and history count are inconsistent."
         )
     if not isinstance(expected_fields, list | tuple) or not all(
         isinstance(field, str) for field in expected_fields
@@ -133,7 +167,14 @@ def _validate_uncached(
     times: list[float] = []
     scalar_dimensions: tuple[str, str, str] | None = None
     resolved_fields: dict[str, str] = {}
+    run_dir = Path(manifest.generated_inputs.run_directory).expanduser().resolve()
+    surface_readbacks: list[dict[str, float]] = []
     for path in paths:
+        resolved_path = path.resolve()
+        if not resolved_path.is_relative_to(run_dir):
+            raise TradeCumulusOutputValidationError(
+                f"Required native history escapes the accepted attempt directory: {path.name}."
+            )
         if not path.is_file():
             raise TradeCumulusOutputValidationError(
                 f"Required native history is unavailable: {path.name}."
@@ -159,7 +200,8 @@ def _validate_uncached(
                 raise TradeCumulusOutputValidationError(
                     "Native histories do not share one scalar-grid dimension order."
                 )
-            _validate_coordinates(dataset, frame_dimensions, path)
+            _validate_coordinates(dataset, frame_dimensions, path, numerical)
+            surface_readbacks.append(_validate_surface_flux_readback(dataset, path, controls))
         finally:
             dataset.close()
 
@@ -173,15 +215,15 @@ def _validate_uncached(
         raise TradeCumulusOutputValidationError(
             "Modeled times must be unique and strictly increasing."
         )
-    for left, right in zip(times, times[1:], strict=False):
+    for actual, expected in zip(times, expected_times, strict=True):
         if not math.isclose(
-            right - left,
-            float(expected_cadence),
+            actual,
+            expected,
             rel_tol=0.0,
             abs_tol=_TIME_TOLERANCE_SECONDS,
         ):
             raise TradeCumulusOutputValidationError(
-                "Modeled times do not reproduce the reviewed output cadence."
+                "Modeled times do not reproduce the exact reviewed timeline."
             )
 
     return {
@@ -195,6 +237,9 @@ def _validate_uncached(
         "scalar_dimensions": list(scalar_dimensions or ()),
         "generated_input_hash_count": len(verified_inputs),
         "cloud_response_required": False,
+        "numerical_realization": numerical.model_dump(mode="json"),
+        "surface_flux_readback": surface_readbacks[-1],
+        "attempt_provenance": provenance_report,
     }
 
 
@@ -296,7 +341,31 @@ def _validate_coordinates(
     dataset: xr.Dataset,
     dimensions: tuple[str, str, str],
     path: Path,
+    numerical: ExactNumericalDomain,
 ) -> None:
+    expected = {
+        dimensions[0]: (
+            numerical.nz,
+            numerical.dz_m,
+            numerical.model_top_m,
+            0.0,
+            numerical.model_top_m,
+        ),
+        dimensions[1]: (
+            numerical.ny,
+            numerical.dy_m,
+            numerical.y_extent_m,
+            numerical.y_min_m,
+            numerical.y_max_m,
+        ),
+        dimensions[2]: (
+            numerical.nx,
+            numerical.dx_m,
+            numerical.x_extent_m,
+            numerical.x_min_m,
+            numerical.x_max_m,
+        ),
+    }
     for dimension in dimensions:
         if dimension not in dataset.coords:
             raise TradeCumulusOutputValidationError(
@@ -316,6 +385,138 @@ def _validate_coordinates(
             raise TradeCumulusOutputValidationError(
                 f"Native coordinate {dimension} in {path.name} lacks length units."
             )
+        values_m = values * 1_000.0 if units.startswith("km") else values
+        (
+            expected_count,
+            expected_spacing_m,
+            expected_extent_m,
+            expected_lower_edge_m,
+            expected_upper_edge_m,
+        ) = expected[dimension]
+        if values_m.size != expected_count:
+            raise TradeCumulusOutputValidationError(
+                f"Native coordinate {dimension} in {path.name} does not match the reviewed grid."
+            )
+        if values_m.size > 1 and not np.allclose(
+            np.diff(values_m),
+            expected_spacing_m,
+            rtol=0.0,
+            atol=max(1.0e-4, expected_spacing_m * 1.0e-5),
+        ):
+            raise TradeCumulusOutputValidationError(
+                f"Native coordinate {dimension} in {path.name} does not match reviewed spacing."
+            )
+        actual_extent_m = (
+            expected_spacing_m
+            if values_m.size == 1
+            else float(values_m[-1] - values_m[0] + expected_spacing_m)
+        )
+        if not math.isclose(
+            actual_extent_m,
+            expected_extent_m,
+            rel_tol=0.0,
+            abs_tol=max(1.0e-3, expected_spacing_m * 1.0e-4),
+        ):
+            raise TradeCumulusOutputValidationError(
+                f"Native coordinate {dimension} in {path.name} does not match reviewed extent."
+            )
+        lower_edge_m = float(values_m[0] - 0.5 * expected_spacing_m)
+        upper_edge_m = float(values_m[-1] + 0.5 * expected_spacing_m)
+        if not math.isclose(
+            lower_edge_m,
+            expected_lower_edge_m,
+            rel_tol=0.0,
+            abs_tol=max(1.0e-3, expected_spacing_m * 1.0e-4),
+        ) or not math.isclose(
+            upper_edge_m,
+            expected_upper_edge_m,
+            rel_tol=0.0,
+            abs_tol=max(1.0e-3, expected_spacing_m * 1.0e-4),
+        ):
+            label = (
+                "the reviewed model top" if dimension == dimensions[0] else "reviewed domain bounds"
+            )
+            raise TradeCumulusOutputValidationError(
+                f"Native coordinate {dimension} in {path.name} does not match {label}."
+            )
+
+
+def _exact_numerical_domain(envelope: VariationEnvelope) -> ExactNumericalDomain:
+    try:
+        return ExactNumericalDomain.model_validate(
+            envelope.numerical_realization.payload.get("exact_domain")
+        )
+    except ValueError as exc:
+        raise TradeCumulusOutputValidationError(
+            "The retained envelope lacks an exact numerical realization."
+        ) from exc
+
+
+def _retained_controls(envelope: VariationEnvelope) -> TradeCumulusControls:
+    try:
+        return normalize_controls(
+            TradeCumulusControls.model_validate(envelope.world_payload.get("controls"))
+        )
+    except ValueError as exc:
+        raise TradeCumulusOutputValidationError(
+            "The retained envelope lacks valid absolute Trade Cumulus controls."
+        ) from exc
+
+
+def _validate_surface_flux_readback(
+    dataset: xr.Dataset,
+    path: Path,
+    controls: TradeCumulusControls,
+) -> dict[str, float]:
+    for field in ("rho", "hfx", "qfx"):
+        name = _field_name(dataset, field)
+        data = _without_time(dataset[name])
+        _validate_units(name, data, path, _REQUIRED_UNITS[field])
+    rho = _without_time(dataset[_field_name(dataset, "rho")])
+    z_dimension = next(
+        (dimension for dimension in rho.dims if str(dimension).lower().startswith("z")),
+        None,
+    )
+    if z_dimension is None:
+        raise TradeCumulusOutputValidationError(
+            f"Density in {path.name} lacks a native vertical dimension."
+        )
+    surface_density = np.asarray(rho.isel({z_dimension: 0}).values, dtype=float)
+    hfx = np.asarray(_without_time(dataset[_field_name(dataset, "hfx")]).values, dtype=float)
+    qfx = np.asarray(_without_time(dataset[_field_name(dataset, "qfx")]).values, dtype=float)
+    if (
+        surface_density.shape != hfx.shape
+        or surface_density.shape != qfx.shape
+        or not np.all(np.isfinite(surface_density))
+        or np.any(surface_density <= 0.0)
+    ):
+        raise TradeCumulusOutputValidationError(
+            f"Surface-flux diagnostics in {path.name} do not share a valid native grid."
+        )
+    implied_heat = hfx / (surface_density * 1_004.0)
+    implied_moisture = qfx / surface_density * 1_000.0
+    if not np.allclose(
+        implied_heat,
+        controls.surface_sensible_heat_flux_k_m_s,
+        rtol=0.02,
+        atol=1.0e-7,
+    ):
+        raise TradeCumulusOutputValidationError(
+            f"Retained sensible-heat flux in {path.name} does not match the reviewed target."
+        )
+    if not np.allclose(
+        implied_moisture,
+        controls.surface_moisture_flux_g_kg_m_s,
+        rtol=0.02,
+        atol=1.0e-6,
+    ):
+        raise TradeCumulusOutputValidationError(
+            f"Retained moisture flux in {path.name} does not match the reviewed target."
+        )
+    return {
+        "surface_sensible_heat_flux_k_m_s": float(np.mean(implied_heat)),
+        "surface_moisture_flux_g_kg_m_s": float(np.mean(implied_moisture)),
+    }
 
 
 def _validate_units(
@@ -365,4 +566,10 @@ def _generated_input_fingerprints(
         manifest.generated_inputs.input_sounding,
         manifest.generated_inputs.cm1_source_customization,
     ]
-    return [_path_fingerprint(Path(value).expanduser()) for value in values if value]
+    fingerprints = [_path_fingerprint(Path(value).expanduser()) for value in values if value]
+    status = manifest.cm1_source_customization_status
+    if isinstance(status, dict):
+        executable = status.get("custom_executable")
+        if isinstance(executable, str) and executable:
+            fingerprints.append(_path_fingerprint(Path(executable).expanduser()))
+    return fingerprints

--- a/app/backend/cloud_chamber/trade_cumulus_output_validation.py
+++ b/app/backend/cloud_chamber/trade_cumulus_output_validation.py
@@ -21,6 +21,12 @@ from cloud_chamber.trade_cumulus_attempt_provenance import (
     TradeCumulusAttemptProvenanceError,
     validate_trade_cumulus_attempt_provenance,
 )
+from cloud_chamber.trade_cumulus_forcing_diagnostics import (
+    FORCING_DIAGNOSTIC_CADENCE_SECONDS,
+    FORCING_DIAGNOSTIC_FIELDS,
+    expected_forcing_profiles,
+    forcing_diagnostic_contract,
+)
 from cloud_chamber.trade_cumulus_recipes import TradeCumulusControls, normalize_controls
 from cloud_chamber.variation_envelope import VariationEnvelope, canonical_payload_sha256
 
@@ -57,11 +63,20 @@ def validate_trade_cumulus_variation_outputs(
 ) -> dict[str, Any]:
     """Validate one ingested Recipe variation and cache by retained artifact identity."""
     paths = [Path(path).expanduser() for path in metadata.model_output_paths]
+    diagnostic_paths = sorted(
+        (
+            Path(path).expanduser()
+            for path in metadata.netcdf_paths
+            if Path(path).name.startswith("cm1out_diag_")
+        ),
+        key=lambda path: path.name,
+    )
     key = (
         manifest.run_id,
         manifest.updated_at.isoformat(),
         metadata.updated_at.isoformat(),
         tuple(_path_fingerprint(path) for path in paths),
+        tuple(_path_fingerprint(path) for path in diagnostic_paths),
         tuple(_generated_input_fingerprints(manifest)),
         canonical_payload_sha256(manifest.cm1_source_customization_status),
     )
@@ -70,7 +85,7 @@ def validate_trade_cumulus_variation_outputs(
         _VALIDATION_CACHE.move_to_end(key)
         return cached
 
-    report = _validate_uncached(manifest, metadata, paths)
+    report = _validate_uncached(manifest, metadata, paths, diagnostic_paths)
     _VALIDATION_CACHE[key] = report
     _VALIDATION_CACHE.move_to_end(key)
     while len(_VALIDATION_CACHE) > _MAX_CACHE_ENTRIES:
@@ -87,6 +102,7 @@ def _validate_uncached(
     manifest: RunManifest,
     metadata: ResultMetadata,
     paths: list[Path],
+    diagnostic_paths: list[Path],
 ) -> dict[str, Any]:
     if manifest.lifecycle_state not in {
         LifecycleState.COMPLETED,
@@ -163,6 +179,14 @@ def _validate_uncached(
             "Ingested output is missing required fields: "
             + ", ".join(metadata.missing_required_output_fields)
         )
+    forcing_diagnostic_report = _validate_forcing_diagnostics(
+        manifest,
+        envelope=envelope,
+        numerical=numerical,
+        controls=controls,
+        diagnostic_paths=diagnostic_paths,
+        duration_seconds=int(expected_duration),
+    )
 
     times: list[float] = []
     scalar_dimensions: tuple[str, str, str] | None = None
@@ -240,7 +264,189 @@ def _validate_uncached(
         "numerical_realization": numerical.model_dump(mode="json"),
         "surface_flux_readback": surface_readbacks[-1],
         "attempt_provenance": provenance_report,
+        "forcing_diagnostics": forcing_diagnostic_report,
     }
+
+
+def _validate_forcing_diagnostics(
+    manifest: RunManifest,
+    *,
+    envelope: VariationEnvelope,
+    numerical: ExactNumericalDomain,
+    controls: TradeCumulusControls,
+    diagnostic_paths: list[Path],
+    duration_seconds: int,
+) -> dict[str, Any]:
+    expected_contract = forcing_diagnostic_contract(
+        duration_seconds=duration_seconds,
+        numerical=numerical,
+    )
+    if envelope.world_payload.get("forcing_diagnostic_contract") != expected_contract:
+        raise TradeCumulusOutputValidationError(
+            "The retained envelope lacks the exact forcing diagnostic contract."
+        )
+    if manifest.run_configuration.get("forcing_diagnostic_contract") != expected_contract:
+        raise TradeCumulusOutputValidationError(
+            "The run configuration disagrees with the forcing diagnostic contract."
+        )
+    if "cm1_domain_diagnostic_netcdf" not in manifest.expected_outputs:
+        raise TradeCumulusOutputValidationError(
+            "The manifest does not declare retained CM1 domain diagnostics."
+        )
+    expected_count = int(expected_contract["expected_file_count"])
+    if len(diagnostic_paths) != expected_count:
+        raise TradeCumulusOutputValidationError(
+            f"Expected {expected_count} forcing diagnostic histories but found "
+            f"{len(diagnostic_paths)}."
+        )
+
+    run_dir = Path(manifest.generated_inputs.run_directory).expanduser().resolve()
+    expected_times = [
+        float(index * FORCING_DIAGNOSTIC_CADENCE_SECONDS) for index in range(expected_count)
+    ]
+    actual_times: list[float] = []
+    final_readback: dict[str, dict[str, float]] = {}
+    for path, expected_time in zip(diagnostic_paths, expected_times, strict=True):
+        resolved_path = path.resolve()
+        if not resolved_path.is_relative_to(run_dir):
+            raise TradeCumulusOutputValidationError(
+                f"Forcing diagnostic escapes the accepted attempt directory: {path.name}."
+            )
+        if not path.is_file():
+            raise TradeCumulusOutputValidationError(
+                f"Forcing diagnostic is unavailable: {path.name}."
+            )
+        try:
+            dataset = xr.open_dataset(path, decode_times=False)
+        except (OSError, ValueError) as exc:
+            raise TradeCumulusOutputValidationError(
+                f"Forcing diagnostic {path.name} is unreadable."
+            ) from exc
+        try:
+            times = _time_values(dataset, path)
+            if len(times) != 1 or not math.isclose(
+                times[0],
+                expected_time,
+                rel_tol=0.0,
+                abs_tol=_TIME_TOLERANCE_SECONDS,
+            ):
+                raise TradeCumulusOutputValidationError(
+                    "Forcing diagnostic times do not reproduce the exact retained cadence."
+                )
+            actual_times.append(times[0])
+            zh_m = _diagnostic_vertical_coordinate(
+                dataset,
+                "zh",
+                expected_count=numerical.nz,
+                spacing_m=numerical.dz_m,
+                model_top_m=numerical.model_top_m,
+                path=path,
+            )
+            zf_m = _diagnostic_vertical_coordinate(
+                dataset,
+                "zf",
+                expected_count=numerical.nz + 1,
+                spacing_m=numerical.dz_m,
+                model_top_m=numerical.model_top_m,
+                path=path,
+            )
+            expected_profiles = expected_forcing_profiles(controls, zh_m=zh_m, zf_m=zf_m)
+            frame_readback: dict[str, dict[str, float]] = {}
+            for field, field_contract in FORCING_DIAGNOSTIC_FIELDS.items():
+                if field not in dataset.data_vars:
+                    raise TradeCumulusOutputValidationError(
+                        f"Required forcing diagnostic field {field} is absent from {path.name}."
+                    )
+                data = dataset[field]
+                if list(data.dims) != field_contract["dimensions"]:
+                    raise TradeCumulusOutputValidationError(
+                        f"Forcing diagnostic field {field} in {path.name} has unsupported "
+                        "dimensions."
+                    )
+                units = str(data.attrs.get("units", "")).strip().lower()
+                expected_units = str(field_contract["units"]).lower()
+                if units != expected_units:
+                    raise TradeCumulusOutputValidationError(
+                        f"Forcing diagnostic field {field} in {path.name} has unsupported units."
+                    )
+                values = np.asarray(data.isel(time=0).values, dtype=float).reshape(-1)
+                if values.size != expected_profiles[field].size or not np.all(np.isfinite(values)):
+                    raise TradeCumulusOutputValidationError(
+                        f"Forcing diagnostic field {field} in {path.name} is incomplete or "
+                        "nonfinite."
+                    )
+                if not np.allclose(
+                    values,
+                    expected_profiles[field],
+                    rtol=2.0e-5,
+                    atol=1.0e-10,
+                ):
+                    raise TradeCumulusOutputValidationError(
+                        f"Forcing diagnostic field {field} does not reproduce the reviewed "
+                        "forcing profile."
+                    )
+                frame_readback[field] = {
+                    "minimum": float(np.min(values)),
+                    "maximum": float(np.max(values)),
+                }
+            final_readback = frame_readback
+        finally:
+            dataset.close()
+
+    return {
+        "schema_version": expected_contract["schema_version"],
+        "file_count": len(diagnostic_paths),
+        "cadence_seconds": FORCING_DIAGNOSTIC_CADENCE_SECONDS,
+        "first_time_seconds": actual_times[0],
+        "last_time_seconds": actual_times[-1],
+        "fields": list(FORCING_DIAGNOSTIC_FIELDS),
+        "final_profile_readback": final_readback,
+    }
+
+
+def _diagnostic_vertical_coordinate(
+    dataset: xr.Dataset,
+    name: str,
+    *,
+    expected_count: int,
+    spacing_m: float,
+    model_top_m: float,
+    path: Path,
+) -> np.ndarray:
+    if name not in dataset.coords:
+        raise TradeCumulusOutputValidationError(
+            f"Forcing diagnostic {path.name} lacks coordinate {name}."
+        )
+    coordinate = dataset.coords[name]
+    units = str(coordinate.attrs.get("units", "")).strip().lower()
+    if units not in {"m", "meter", "meters", "km", "kilometer", "kilometers"}:
+        raise TradeCumulusOutputValidationError(
+            f"Forcing diagnostic coordinate {name} in {path.name} lacks length units."
+        )
+    values = np.asarray(coordinate.values, dtype=float)
+    values_m = values * 1_000.0 if units.startswith("km") else values
+    if (
+        values_m.ndim != 1
+        or values_m.size != expected_count
+        or not np.all(np.isfinite(values_m))
+        or (values_m.size > 1 and not np.allclose(np.diff(values_m), spacing_m))
+    ):
+        raise TradeCumulusOutputValidationError(
+            f"Forcing diagnostic coordinate {name} in {path.name} does not match the "
+            "reviewed vertical grid."
+        )
+    expected_start = 0.0 if name == "zf" else spacing_m / 2.0
+    expected_end = model_top_m if name == "zf" else model_top_m - spacing_m / 2.0
+    if not math.isclose(values_m[0], expected_start, abs_tol=1.0e-4) or not math.isclose(
+        values_m[-1],
+        expected_end,
+        abs_tol=1.0e-4,
+    ):
+        raise TradeCumulusOutputValidationError(
+            f"Forcing diagnostic coordinate {name} in {path.name} does not match the "
+            "reviewed model top."
+        )
+    return values_m
 
 
 def _variation_envelope(manifest: RunManifest) -> VariationEnvelope:

--- a/app/backend/cloud_chamber/trade_cumulus_output_validation.py
+++ b/app/backend/cloud_chamber/trade_cumulus_output_validation.py
@@ -1,0 +1,368 @@
+"""Strict retained-output validation for Trade Cumulus Recipe variations."""
+
+from __future__ import annotations
+
+import math
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import xarray as xr
+
+from cloud_chamber.generated_input_identity import (
+    GeneratedInputIdentityError,
+    verify_generated_input_identity,
+)
+from cloud_chamber.result_ingest import ResultMetadata
+from cloud_chamber.run_manifest import LifecycleState, RunManifest
+from cloud_chamber.variation_envelope import VariationEnvelope
+
+
+class TradeCumulusOutputValidationError(ValueError):
+    """Raised when retained output cannot support an available Simulation."""
+
+
+_VALIDATION_CACHE: OrderedDict[tuple[object, ...], dict[str, Any]] = OrderedDict()
+_MAX_CACHE_ENTRIES = 16
+_TIME_TOLERANCE_SECONDS = 1.0e-3
+_REQUIRED_UNITS = {
+    "ql": ("kg kg-1", "kg/kg", "kg kg^-1"),
+    "qv": ("kg kg-1", "kg/kg", "kg kg^-1"),
+    "th": ("k",),
+    "prs": ("pa",),
+    "u": ("m s-1", "m/s", "m s^-1"),
+    "v": ("m s-1", "m/s", "m s^-1"),
+    "w": ("m s-1", "m/s", "m s^-1"),
+}
+_ALIASES = {
+    "u": ("u", "uinterp"),
+    "v": ("v", "vinterp"),
+    "w": ("w", "winterp"),
+}
+
+
+def validate_trade_cumulus_variation_outputs(
+    manifest: RunManifest,
+    metadata: ResultMetadata,
+) -> dict[str, Any]:
+    """Validate one ingested Recipe variation and cache by retained artifact identity."""
+    paths = [Path(path).expanduser() for path in metadata.model_output_paths]
+    key = (
+        manifest.run_id,
+        manifest.updated_at.isoformat(),
+        metadata.updated_at.isoformat(),
+        tuple(_path_fingerprint(path) for path in paths),
+        tuple(_generated_input_fingerprints(manifest)),
+    )
+    cached = _VALIDATION_CACHE.get(key)
+    if cached is not None:
+        _VALIDATION_CACHE.move_to_end(key)
+        return cached
+
+    report = _validate_uncached(manifest, metadata, paths)
+    _VALIDATION_CACHE[key] = report
+    _VALIDATION_CACHE.move_to_end(key)
+    while len(_VALIDATION_CACHE) > _MAX_CACHE_ENTRIES:
+        _VALIDATION_CACHE.popitem(last=False)
+    return report
+
+
+def clear_trade_cumulus_output_validation_cache() -> None:
+    """Clear bounded validation state for deterministic tests."""
+    _VALIDATION_CACHE.clear()
+
+
+def _validate_uncached(
+    manifest: RunManifest,
+    metadata: ResultMetadata,
+    paths: list[Path],
+) -> dict[str, Any]:
+    if manifest.lifecycle_state not in {
+        LifecycleState.COMPLETED,
+        LifecycleState.INGESTED,
+        LifecycleState.SAVED,
+    }:
+        raise TradeCumulusOutputValidationError(
+            "Trade Cumulus availability requires a completed or ingested attempt."
+        )
+    if manifest.execution.exit_code != 0 or manifest.execution.finished_at is None:
+        raise TradeCumulusOutputValidationError(
+            "Trade Cumulus availability requires normal CM1 completion."
+        )
+    try:
+        verified_inputs = verify_generated_input_identity(manifest)
+    except (OSError, ValueError, GeneratedInputIdentityError) as exc:
+        raise TradeCumulusOutputValidationError(
+            "Generated inputs changed after the reviewed package was created."
+        ) from exc
+
+    envelope = _variation_envelope(manifest)
+    observation = envelope.observation_plan.payload
+    expected_count = observation.get("expected_history_count")
+    expected_cadence = observation.get("output_cadence_seconds")
+    expected_fields = observation.get("retained_field_inventory")
+    if not isinstance(expected_count, int) or expected_count <= 0:
+        raise TradeCumulusOutputValidationError(
+            "The retained envelope lacks an exact expected history count."
+        )
+    if not isinstance(expected_cadence, int | float) or expected_cadence <= 0:
+        raise TradeCumulusOutputValidationError(
+            "The retained envelope lacks an exact output cadence."
+        )
+    if not isinstance(expected_fields, list | tuple) or not all(
+        isinstance(field, str) for field in expected_fields
+    ):
+        raise TradeCumulusOutputValidationError(
+            "The retained envelope lacks a required field inventory."
+        )
+    if len(paths) != expected_count:
+        raise TradeCumulusOutputValidationError(
+            f"Expected {expected_count} native histories but found {len(paths)}."
+        )
+    if metadata.model_output_file_count not in {0, len(paths)}:
+        raise TradeCumulusOutputValidationError(
+            "Ingested output inventory disagrees with the retained histories."
+        )
+    if metadata.missing_required_output_fields:
+        raise TradeCumulusOutputValidationError(
+            "Ingested output is missing required fields: "
+            + ", ".join(metadata.missing_required_output_fields)
+        )
+
+    times: list[float] = []
+    scalar_dimensions: tuple[str, str, str] | None = None
+    resolved_fields: dict[str, str] = {}
+    for path in paths:
+        if not path.is_file():
+            raise TradeCumulusOutputValidationError(
+                f"Required native history is unavailable: {path.name}."
+            )
+        try:
+            dataset = xr.open_dataset(path, decode_times=False)
+        except (OSError, ValueError) as exc:
+            raise TradeCumulusOutputValidationError(
+                f"Native history {path.name} is unreadable."
+            ) from exc
+        try:
+            local_times = _time_values(dataset, path)
+            times.extend(local_times)
+            frame_dimensions = _validate_fields(
+                dataset,
+                expected_fields=tuple(expected_fields),
+                path=path,
+                resolved_fields=resolved_fields,
+            )
+            if scalar_dimensions is None:
+                scalar_dimensions = frame_dimensions
+            elif scalar_dimensions != frame_dimensions:
+                raise TradeCumulusOutputValidationError(
+                    "Native histories do not share one scalar-grid dimension order."
+                )
+            _validate_coordinates(dataset, frame_dimensions, path)
+        finally:
+            dataset.close()
+
+    if len(times) != expected_count:
+        raise TradeCumulusOutputValidationError(
+            f"Expected {expected_count} modeled times but found {len(times)}."
+        )
+    if any(not math.isfinite(value) for value in times):
+        raise TradeCumulusOutputValidationError("Modeled times must be finite.")
+    if any(right <= left for left, right in zip(times, times[1:], strict=False)):
+        raise TradeCumulusOutputValidationError(
+            "Modeled times must be unique and strictly increasing."
+        )
+    for left, right in zip(times, times[1:], strict=False):
+        if not math.isclose(
+            right - left,
+            float(expected_cadence),
+            rel_tol=0.0,
+            abs_tol=_TIME_TOLERANCE_SECONDS,
+        ):
+            raise TradeCumulusOutputValidationError(
+                "Modeled times do not reproduce the reviewed output cadence."
+            )
+
+    return {
+        "passed": True,
+        "history_count": len(paths),
+        "time_count": len(times),
+        "first_time_seconds": times[0],
+        "last_time_seconds": times[-1],
+        "output_cadence_seconds": float(expected_cadence),
+        "resolved_fields": resolved_fields,
+        "scalar_dimensions": list(scalar_dimensions or ()),
+        "generated_input_hash_count": len(verified_inputs),
+        "cloud_response_required": False,
+    }
+
+
+def _variation_envelope(manifest: RunManifest) -> VariationEnvelope:
+    payload = manifest.run_configuration.get("variation_envelope")
+    try:
+        envelope = VariationEnvelope.model_validate(payload)
+    except ValueError as exc:
+        raise TradeCumulusOutputValidationError(
+            "The retained shared variation envelope is invalid."
+        ) from exc
+    if (
+        envelope.world_id != "trade_cumulus"
+        or envelope.recipe_id != "canonical_bomex_trade_cumulus"
+        or envelope.recipe_contract_version != "1"
+    ):
+        raise TradeCumulusOutputValidationError(
+            "The retained output is outside the current Trade Cumulus Recipe contract."
+        )
+    return envelope
+
+
+def _validate_fields(
+    dataset: xr.Dataset,
+    *,
+    expected_fields: tuple[str, ...],
+    path: Path,
+    resolved_fields: dict[str, str],
+) -> tuple[str, str, str]:
+    ql_name = _field_name(dataset, "ql")
+    ql = _without_time(dataset[ql_name])
+    dimensions = _scalar_dimensions(ql, path)
+    for field in expected_fields:
+        name = _field_name(dataset, field)
+        data = _without_time(dataset[name])
+        if data.ndim < 2:
+            raise TradeCumulusOutputValidationError(
+                f"Required field {name} in {path.name} has unsupported dimensions."
+            )
+        values = np.asarray(data.values)
+        if not np.issubdtype(values.dtype, np.number):
+            raise TradeCumulusOutputValidationError(
+                f"Required field {name} in {path.name} is not numeric."
+            )
+        if not np.all(np.isfinite(values)):
+            raise TradeCumulusOutputValidationError(
+                f"Required field {name} in {path.name} contains nonfinite values."
+            )
+        resolved_fields[field] = name
+        if field in _REQUIRED_UNITS:
+            _validate_units(name, data, path, _REQUIRED_UNITS[field])
+    for lens_field in ("ql", "u", "v", "w"):
+        name = _field_name(dataset, lens_field)
+        data = _without_time(dataset[name])
+        values = np.asarray(data.values)
+        if not np.all(np.isfinite(values)):
+            raise TradeCumulusOutputValidationError(
+                f"Updraft Lens field {name} in {path.name} contains nonfinite values."
+            )
+        if lens_field in _REQUIRED_UNITS:
+            _validate_units(name, data, path, _REQUIRED_UNITS[lens_field])
+        resolved_fields[lens_field] = name
+    return dimensions
+
+
+def _field_name(dataset: xr.Dataset, field: str) -> str:
+    candidates = _ALIASES.get(field, (field,))
+    name = next((candidate for candidate in candidates if candidate in dataset.data_vars), None)
+    if name is None:
+        raise TradeCumulusOutputValidationError(f"Required native field {field} is absent.")
+    return name
+
+
+def _without_time(data: xr.DataArray) -> xr.DataArray:
+    time_dimension = next(
+        (dimension for dimension in data.dims if str(dimension).lower() in {"time", "t"}),
+        None,
+    )
+    return data.isel({time_dimension: 0}, drop=True) if time_dimension else data
+
+
+def _scalar_dimensions(data: xr.DataArray, path: Path) -> tuple[str, str, str]:
+    if data.ndim != 3:
+        raise TradeCumulusOutputValidationError(
+            f"Cloud liquid in {path.name} is not a native three-dimensional scalar field."
+        )
+    names = tuple(str(dimension) for dimension in data.dims)
+    z = next((dimension for dimension in names if dimension.lower().startswith("z")), None)
+    y = next((dimension for dimension in names if dimension.lower().startswith("y")), None)
+    x = next((dimension for dimension in names if dimension.lower().startswith("x")), None)
+    if z is None or y is None or x is None or len({z, y, x}) != 3:
+        raise TradeCumulusOutputValidationError(
+            f"Cloud liquid in {path.name} lacks native x/y/z dimensions."
+        )
+    return z, y, x
+
+
+def _validate_coordinates(
+    dataset: xr.Dataset,
+    dimensions: tuple[str, str, str],
+    path: Path,
+) -> None:
+    for dimension in dimensions:
+        if dimension not in dataset.coords:
+            raise TradeCumulusOutputValidationError(
+                f"Native coordinate {dimension} is absent from {path.name}."
+            )
+        values = np.asarray(dataset.coords[dimension].values, dtype=float)
+        if values.ndim != 1 or not values.size or not np.all(np.isfinite(values)):
+            raise TradeCumulusOutputValidationError(
+                f"Native coordinate {dimension} in {path.name} is invalid."
+            )
+        if values.size > 1 and not np.all(np.diff(values) > 0):
+            raise TradeCumulusOutputValidationError(
+                f"Native coordinate {dimension} in {path.name} is not strictly increasing."
+            )
+        units = str(dataset.coords[dimension].attrs.get("units", "")).strip().lower()
+        if units not in {"m", "meter", "meters", "km", "kilometer", "kilometers"}:
+            raise TradeCumulusOutputValidationError(
+                f"Native coordinate {dimension} in {path.name} lacks length units."
+            )
+
+
+def _validate_units(
+    field: str,
+    data: xr.DataArray,
+    path: Path,
+    accepted: tuple[str, ...],
+) -> None:
+    units = str(data.attrs.get("units", "")).strip().lower()
+    normalized = units.replace("**", "^").replace(" ", "")
+    normalized_accepted = {
+        candidate.replace("**", "^").replace(" ", "").lower() for candidate in accepted
+    }
+    if normalized not in normalized_accepted:
+        raise TradeCumulusOutputValidationError(
+            f"Required field {field} in {path.name} has unsupported units {units or 'missing'}."
+        )
+
+
+def _time_values(dataset: xr.Dataset, path: Path) -> list[float]:
+    if "time" not in dataset.coords and "time" not in dataset.variables:
+        raise TradeCumulusOutputValidationError(f"Native history {path.name} lacks modeled time.")
+    raw = np.asarray(dataset["time"].values, dtype=float).reshape(-1)
+    if raw.size != 1:
+        raise TradeCumulusOutputValidationError(
+            f"Native history {path.name} must contain exactly one saved modeled time."
+        )
+    units = str(dataset["time"].attrs.get("units", "")).strip().lower()
+    if units not in {"s", "sec", "secs", "second", "seconds"}:
+        raise TradeCumulusOutputValidationError(f"Modeled time in {path.name} lacks seconds units.")
+    return [float(raw[0])]
+
+
+def _path_fingerprint(path: Path) -> tuple[str, int | None, int | None]:
+    try:
+        stat = path.stat()
+    except OSError:
+        return str(path), None, None
+    return str(path), stat.st_size, stat.st_mtime_ns
+
+
+def _generated_input_fingerprints(
+    manifest: RunManifest,
+) -> list[tuple[str, int | None, int | None]]:
+    values = [
+        manifest.generated_inputs.namelist_input,
+        manifest.generated_inputs.input_sounding,
+        manifest.generated_inputs.cm1_source_customization,
+    ]
+    return [_path_fingerprint(Path(value).expanduser()) for value in values if value]

--- a/app/backend/cloud_chamber/trade_cumulus_recipes.py
+++ b/app/backend/cloud_chamber/trade_cumulus_recipes.py
@@ -1,0 +1,585 @@
+"""Approved Trade Cumulus Recipe controls and deterministic profile generator."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from cloud_chamber.run_cost import ObservationPlan, RunCostProfile
+from cloud_chamber.variation_envelope import VariationDifference
+
+RECIPE_ID: Literal["canonical_bomex_trade_cumulus"] = "canonical_bomex_trade_cumulus"
+RECIPE_NAME = "Canonical BOMEX Trade Cumulus"
+RECIPE_CONTRACT_VERSION: Literal["1"] = "1"
+RUN_COST_RECIPE_VERSION = "approved_variation_contract_v1"
+
+SURFACE_PRESSURE_PA = 101_500.0
+SURFACE_THETA_K = 298.7
+REFERENCE_LAYER_MEAN_U_M_S = -7.50
+REFERENCE_LAYER_MEAN_V_M_S = 0.0
+REFERENCE_SUB_INVERSION_QT_G_KG = 16.65
+REFERENCE_FREE_TROPOSPHERIC_RH_PERCENT = 41.0
+TARGET_TOLERANCE = 0.02
+
+
+class TradeCumulusControls(BaseModel):
+    """Direct physical values approved by the #448 PM correction."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    surface_sensible_heat_flux_k_m_s: float = Field(default=0.008, ge=-0.020, le=0.050)
+    surface_moisture_flux_g_kg_m_s: float = Field(default=0.052, ge=-0.10, le=0.25)
+    sub_inversion_total_water_g_kg: float = Field(
+        default=REFERENCE_SUB_INVERSION_QT_G_KG, ge=0.0, le=25.0
+    )
+    inversion_base_m_agl: float = Field(default=520.0, ge=300.0, le=4_000.0)
+    inversion_thickness_m: float = Field(default=960.0, ge=50.0, le=2_000.0)
+    inversion_strength_k: float = Field(default=3.7, ge=-5.0, le=20.0)
+    free_tropospheric_rh_percent: float = Field(
+        default=REFERENCE_FREE_TROPOSPHERIC_RH_PERCENT, ge=0.0, le=100.0
+    )
+    cloud_layer_shear_m_s: float = Field(default=4.14, ge=0.0, le=50.0)
+    cloud_layer_shear_direction_deg: float = Field(default=0.0, ge=0.0, le=360.0)
+    cloud_layer_mean_u_m_s: float = Field(default=REFERENCE_LAYER_MEAN_U_M_S, ge=-50.0, le=50.0)
+    cloud_layer_mean_v_m_s: float = Field(default=REFERENCE_LAYER_MEAN_V_M_S, ge=-50.0, le=50.0)
+    large_scale_vertical_motion_m_s: float = Field(default=-0.0065, ge=-0.050, le=0.050)
+    temperature_tendency_k_day: float = Field(default=-2.0, ge=-20.0, le=10.0)
+    total_water_tendency_g_kg_day: float = Field(default=-1.0368, ge=-20.0, le=10.0)
+
+
+class TradeCumulusProfileLevel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    height_m: float
+    pressure_pa: float
+    theta_l_k: float
+    total_water_g_kg: float
+    relative_humidity_percent: float
+    u_m_s: float
+    v_m_s: float
+
+
+class TradeCumulusForcingLevel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    height_m: float
+    vertical_motion_m_s: float
+    temperature_tendency_k_day: float
+    total_water_tendency_g_kg_day: float
+
+
+class TradeCumulusDiagnostics(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    inversion_top_m_agl: float
+    model_top_m: float
+    sub_inversion_total_water_g_kg: float
+    free_tropospheric_rh_percent: float
+    cloud_layer_shear_m_s: float
+    cloud_layer_shear_direction_deg: float
+    cloud_layer_mean_u_m_s: float
+    cloud_layer_mean_v_m_s: float
+    initial_saturated_level_count: int
+    minimum_theta_gradient_k_km: float
+    labels: list[str]
+
+
+class ResolvedTradeCumulusRecipe(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    recipe_id: Literal["canonical_bomex_trade_cumulus"] = RECIPE_ID
+    recipe_name: str = RECIPE_NAME
+    controls: dict[str, float]
+    achieved_controls: dict[str, float]
+    sounding: list[TradeCumulusProfileLevel]
+    forcing_profile: list[TradeCumulusForcingLevel]
+    observation_plan: ObservationPlan
+    resolved_cost_profile: RunCostProfile
+    differences: list[VariationDifference]
+    warnings: list[str]
+    blocking_errors: list[str]
+    diagnostics: TradeCumulusDiagnostics
+
+
+def default_controls() -> TradeCumulusControls:
+    return TradeCumulusControls()
+
+
+def normalize_controls(
+    controls: TradeCumulusControls,
+    *,
+    reference: TradeCumulusControls | None = None,
+) -> TradeCumulusControls:
+    """Remove inactive direction state when the shear magnitude is zero."""
+    baseline = reference or default_controls()
+    payload = controls.model_dump(mode="json")
+    if controls.cloud_layer_shear_m_s == 0.0:
+        payload["cloud_layer_shear_direction_deg"] = baseline.cloud_layer_shear_direction_deg
+    elif controls.cloud_layer_shear_direction_deg == 360.0:
+        payload["cloud_layer_shear_direction_deg"] = 0.0
+    return TradeCumulusControls.model_validate(payload)
+
+
+def resolve_trade_cumulus_recipe(
+    *,
+    controls: TradeCumulusControls,
+    parent_controls: TradeCumulusControls,
+    catalog_profile: RunCostProfile,
+) -> ResolvedTradeCumulusRecipe:
+    if catalog_profile.world_id != "trade_cumulus" or catalog_profile.recipe_id != RECIPE_ID:
+        raise ValueError("Selected run profile does not belong to Trade Cumulus.")
+    effective = normalize_controls(controls)
+    parent = normalize_controls(parent_controls)
+    model_top_m = _model_top(catalog_profile)
+    inversion_top = effective.inversion_base_m_agl + effective.inversion_thickness_m
+    errors: list[str] = []
+    warnings = _scientific_warnings(effective)
+    if inversion_top >= model_top_m - 100.0:
+        errors.append(
+            f"The requested inversion top is {inversion_top:,.0f} m AGL, but the selected "
+            f"run profile ends at {model_top_m:,.0f} m. Choose a lower inversion or a "
+            "numerical profile with a taller domain."
+        )
+    if catalog_profile.estimate_basis == "uncharacterized":
+        errors.append(
+            "The selected run profile remains uncharacterized and cannot be packaged "
+            "without a bounded characterization decision."
+        )
+
+    sounding = _generate_sounding(effective, model_top_m)
+    forcing = _generate_forcing(effective, model_top_m)
+    achieved = _achieved_controls(effective, sounding, forcing)
+    errors.extend(_target_errors(effective, achieved))
+    minimum_gradient = _minimum_theta_gradient(sounding)
+    saturated_count = sum(
+        level.relative_humidity_percent >= 100.0 - TARGET_TOLERANCE for level in sounding
+    )
+    labels: list[str] = []
+    if minimum_gradient < 0.0:
+        labels.append("Static instability possible")
+    if saturated_count:
+        labels.append("Initial saturation present")
+    if effective.cloud_layer_shear_m_s >= 30.0:
+        labels.append("Strong cloud-layer shear")
+    if effective.large_scale_vertical_motion_m_s > 0.0:
+        labels.append("Large-scale ascent")
+    elif effective.large_scale_vertical_motion_m_s < 0.0:
+        labels.append("Large-scale subsidence")
+    else:
+        labels.append("No large-scale vertical motion")
+
+    return ResolvedTradeCumulusRecipe(
+        controls=effective.model_dump(mode="json"),
+        achieved_controls=achieved,
+        sounding=sounding,
+        forcing_profile=forcing,
+        observation_plan=catalog_profile.observation_plan,
+        resolved_cost_profile=catalog_profile,
+        differences=_control_differences(achieved, _achieved_parent(parent, model_top_m)),
+        warnings=warnings,
+        blocking_errors=errors,
+        diagnostics=TradeCumulusDiagnostics(
+            inversion_top_m_agl=inversion_top,
+            model_top_m=model_top_m,
+            sub_inversion_total_water_g_kg=achieved["sub_inversion_total_water_g_kg"],
+            free_tropospheric_rh_percent=achieved["free_tropospheric_rh_percent"],
+            cloud_layer_shear_m_s=achieved["cloud_layer_shear_m_s"],
+            cloud_layer_shear_direction_deg=achieved["cloud_layer_shear_direction_deg"],
+            cloud_layer_mean_u_m_s=achieved["cloud_layer_mean_u_m_s"],
+            cloud_layer_mean_v_m_s=achieved["cloud_layer_mean_v_m_s"],
+            initial_saturated_level_count=saturated_count,
+            minimum_theta_gradient_k_km=minimum_gradient,
+            labels=labels,
+        ),
+    )
+
+
+def _generate_sounding(
+    controls: TradeCumulusControls,
+    model_top_m: float,
+) -> list[TradeCumulusProfileLevel]:
+    heights = _profile_heights(model_top_m, controls.inversion_base_m_agl)
+    inversion_top = controls.inversion_base_m_agl + controls.inversion_thickness_m
+    heights = sorted({*heights, inversion_top})
+    shear_radians = math.radians(controls.cloud_layer_shear_direction_deg)
+    delta_u = controls.cloud_layer_shear_m_s * math.cos(shear_radians)
+    delta_v = controls.cloud_layer_shear_m_s * math.sin(shear_radians)
+    u0 = controls.cloud_layer_mean_u_m_s - delta_u / 2.0
+    v0 = controls.cloud_layer_mean_v_m_s - delta_v / 2.0
+    pressure = SURFACE_PRESSURE_PA
+    previous_height = 0.0
+    output: list[TradeCumulusProfileLevel] = []
+    raw_sub_water: list[tuple[float, float]] = []
+    for height in heights:
+        if height <= controls.inversion_base_m_agl:
+            fraction = height / max(controls.inversion_base_m_agl, 1.0)
+            raw_sub_water.append((height, 1.0 - 0.0412 * fraction))
+    raw_mean = _layer_mean(raw_sub_water, 0.0, controls.inversion_base_m_agl)
+    sub_scale = controls.sub_inversion_total_water_g_kg / max(raw_mean, 1.0e-12)
+
+    for height in heights:
+        theta = _theta_at(height, controls)
+        if output:
+            previous_theta = output[-1].theta_l_k
+            mean_theta = 0.5 * (previous_theta + theta)
+            mean_temperature = mean_theta * (pressure / 100_000.0) ** (287.05 / 1004.0)
+            pressure *= math.exp(
+                -9.80665 * (height - previous_height) / max(287.05 * mean_temperature, 1.0)
+            )
+        temperature = theta * (pressure / 100_000.0) ** (287.05 / 1004.0)
+        saturation = _saturation_mixing_ratio_g_kg(pressure, temperature)
+        if height <= controls.inversion_base_m_agl:
+            fraction = height / max(controls.inversion_base_m_agl, 1.0)
+            total_water = sub_scale * (1.0 - 0.0412 * fraction)
+        elif height < inversion_top:
+            base_value = sub_scale * (1.0 - 0.0412)
+            target_value = controls.free_tropospheric_rh_percent / 100.0 * saturation
+            fraction = (height - controls.inversion_base_m_agl) / max(
+                controls.inversion_thickness_m, 1.0
+            )
+            total_water = base_value + (target_value - base_value) * fraction
+        else:
+            total_water = controls.free_tropospheric_rh_percent / 100.0 * saturation
+        rh = 0.0 if saturation <= 0.0 else 100.0 * total_water / saturation
+        shear_fraction = min(max(height / 3_000.0, 0.0), 1.0)
+        output.append(
+            TradeCumulusProfileLevel(
+                height_m=height,
+                pressure_pa=pressure,
+                theta_l_k=theta,
+                total_water_g_kg=max(0.0, total_water),
+                relative_humidity_percent=max(0.0, rh),
+                u_m_s=u0 + delta_u * shear_fraction,
+                v_m_s=v0 + delta_v * shear_fraction,
+            )
+        )
+        previous_height = height
+    return output
+
+
+def _generate_forcing(
+    controls: TradeCumulusControls,
+    model_top_m: float,
+) -> list[TradeCumulusForcingLevel]:
+    output: list[TradeCumulusForcingLevel] = []
+    for height in _profile_heights(model_top_m, controls.inversion_base_m_agl):
+        if height <= 1_500.0:
+            w_factor = height / 1_500.0
+            temperature_factor = 1.0
+        elif height <= 2_100.0:
+            w_factor = 1.0 - (height - 1_500.0) / 600.0
+            temperature_factor = w_factor
+        else:
+            w_factor = 0.0
+            temperature_factor = 0.0
+        if height <= 300.0:
+            moisture_factor = 1.0
+        elif height <= 500.0:
+            moisture_factor = 1.0 - (height - 300.0) / 200.0
+        else:
+            moisture_factor = 0.0
+        output.append(
+            TradeCumulusForcingLevel(
+                height_m=height,
+                vertical_motion_m_s=controls.large_scale_vertical_motion_m_s * w_factor,
+                temperature_tendency_k_day=(
+                    controls.temperature_tendency_k_day * temperature_factor
+                ),
+                total_water_tendency_g_kg_day=(
+                    controls.total_water_tendency_g_kg_day * moisture_factor
+                ),
+            )
+        )
+    return output
+
+
+def _achieved_parent(
+    controls: TradeCumulusControls,
+    model_top_m: float,
+) -> dict[str, float]:
+    sounding = _generate_sounding(controls, model_top_m)
+    forcing = _generate_forcing(controls, model_top_m)
+    return _achieved_controls(controls, sounding, forcing)
+
+
+def _achieved_controls(
+    controls: TradeCumulusControls,
+    sounding: list[TradeCumulusProfileLevel],
+    forcing: list[TradeCumulusForcingLevel],
+) -> dict[str, float]:
+    inversion_top = controls.inversion_base_m_agl + controls.inversion_thickness_m
+    sub_water = [(level.height_m, level.total_water_g_kg) for level in sounding]
+    free_rh = [(level.height_m, level.relative_humidity_percent) for level in sounding]
+    lower = _interpolated_level(sounding, 0.0)
+    upper = _interpolated_level(sounding, 3_000.0)
+    delta_u = upper.u_m_s - lower.u_m_s
+    delta_v = upper.v_m_s - lower.v_m_s
+    shear = math.hypot(delta_u, delta_v)
+    direction = 0.0 if shear < 1.0e-9 else math.degrees(math.atan2(delta_v, delta_u)) % 360.0
+    winds_u = [(level.height_m, level.u_m_s) for level in sounding]
+    winds_v = [(level.height_m, level.v_m_s) for level in sounding]
+    return {
+        "surface_sensible_heat_flux_k_m_s": controls.surface_sensible_heat_flux_k_m_s,
+        "surface_moisture_flux_g_kg_m_s": controls.surface_moisture_flux_g_kg_m_s,
+        "sub_inversion_total_water_g_kg": _layer_mean(
+            sub_water, 0.0, controls.inversion_base_m_agl
+        ),
+        "inversion_base_m_agl": controls.inversion_base_m_agl,
+        "inversion_thickness_m": controls.inversion_thickness_m,
+        "inversion_strength_k": (
+            _interpolated_level(sounding, inversion_top).theta_l_k
+            - _interpolated_level(sounding, controls.inversion_base_m_agl).theta_l_k
+        ),
+        "free_tropospheric_rh_percent": _layer_mean(
+            free_rh, inversion_top, min(3_000.0, sounding[-1].height_m)
+        ),
+        "cloud_layer_shear_m_s": shear,
+        "cloud_layer_shear_direction_deg": direction,
+        "cloud_layer_mean_u_m_s": _layer_mean(winds_u, 0.0, 3_000.0),
+        "cloud_layer_mean_v_m_s": _layer_mean(winds_v, 0.0, 3_000.0),
+        "large_scale_vertical_motion_m_s": _signed_extreme(
+            [level.vertical_motion_m_s for level in forcing]
+        ),
+        "temperature_tendency_k_day": _signed_extreme(
+            [level.temperature_tendency_k_day for level in forcing]
+        ),
+        "total_water_tendency_g_kg_day": _signed_extreme(
+            [level.total_water_tendency_g_kg_day for level in forcing]
+        ),
+    }
+
+
+def _target_errors(
+    requested: TradeCumulusControls,
+    achieved: dict[str, float],
+) -> list[str]:
+    errors: list[str] = []
+    for key, target in requested.model_dump(mode="json").items():
+        actual = achieved[key]
+        if not math.isfinite(actual):
+            errors.append(
+                f"{_label(key)} target {target:g} is not attainable because the selected "
+                "profile contains no valid sampling layer."
+            )
+            continue
+        tolerance = (
+            0.05 if key.endswith("_percent") else 0.1 if key.endswith("_deg") else TARGET_TOLERANCE
+        )
+        difference = (
+            abs(((actual - target + 180.0) % 360.0) - 180.0)
+            if key.endswith("_deg")
+            else abs(actual - target)
+        )
+        if difference > tolerance:
+            errors.append(
+                f"{_label(key)} target {target:g} is not attainable; generated value is "
+                f"{actual:g} (tolerance {tolerance:g})."
+            )
+    return errors
+
+
+def _control_differences(
+    after: dict[str, float],
+    before: dict[str, float],
+) -> list[VariationDifference]:
+    differences: list[VariationDifference] = []
+    for key, metadata in _DIFFERENCE_METADATA.items():
+        if math.isclose(after[key], before[key], rel_tol=0.0, abs_tol=1.0e-6):
+            continue
+        category, label, units = metadata
+        differences.append(
+            VariationDifference(
+                category=category,
+                path=f"controls.{key}",
+                label=label,
+                before=before[key],
+                after=after[key],
+                units=units,
+            )
+        )
+    return differences
+
+
+def _scientific_warnings(controls: TradeCumulusControls) -> list[str]:
+    warnings: list[str] = []
+    if controls.surface_sensible_heat_flux_k_m_s < 0.0:
+        warnings.append("Surface sensible heat flux is downward.")
+    if controls.surface_moisture_flux_g_kg_m_s < 0.0:
+        warnings.append("Surface moisture flux is downward.")
+    if controls.inversion_strength_k < 0.0:
+        warnings.append(
+            "The requested liquid-water-potential-temperature jump reverses the inversion; "
+            "static instability may dominate the result."
+        )
+    if controls.free_tropospheric_rh_percent >= 95.0:
+        warnings.append("The authored free troposphere is near saturation.")
+    if controls.cloud_layer_shear_m_s >= 30.0:
+        warnings.append("Cloud-layer shear is much stronger than the canonical BOMEX reference.")
+    if controls.large_scale_vertical_motion_m_s > 0.0:
+        warnings.append("The canonical large-scale subsidence profile is reversed to ascent.")
+    if controls.temperature_tendency_k_day > 0.0:
+        warnings.append("The canonical radiative cooling profile is reversed to warming.")
+    if controls.total_water_tendency_g_kg_day > 0.0:
+        warnings.append("The canonical drying tendency is reversed to moistening.")
+    return warnings
+
+
+def _theta_at(height_m: float, controls: TradeCumulusControls) -> float:
+    base = controls.inversion_base_m_agl
+    top = base + controls.inversion_thickness_m
+    if height_m <= base:
+        return SURFACE_THETA_K
+    if height_m <= top:
+        return SURFACE_THETA_K + controls.inversion_strength_k * (height_m - base) / (top - base)
+    return SURFACE_THETA_K + controls.inversion_strength_k + 0.0062 * (height_m - top)
+
+
+def _profile_heights(model_top_m: float, inversion_base_m: float) -> list[float]:
+    values = {float(index) for index in range(0, int(model_top_m) + 101, 100)}
+    values.update(
+        {
+            inversion_base_m,
+            min(model_top_m + 100.0, inversion_base_m + 50.0),
+            300.0,
+            500.0,
+            1_500.0,
+            2_100.0,
+            3_000.0,
+            model_top_m + 100.0,
+        }
+    )
+    return sorted(value for value in values if 0.0 <= value <= model_top_m + 100.0)
+
+
+def _model_top(profile: RunCostProfile) -> float:
+    grid = profile.numerical_realization.grid.replace(" ", "").split("×")
+    spacing = profile.numerical_realization.spacing.replace("about", "").strip().split("×")
+    try:
+        nz = float(grid[-1])
+        dz = float(spacing[-1].strip().split()[0])
+    except (IndexError, ValueError) as exc:
+        raise ValueError("Trade Cumulus run profile has an invalid vertical realization.") from exc
+    return nz * dz
+
+
+def _saturation_mixing_ratio_g_kg(pressure_pa: float, temperature_k: float) -> float:
+    temperature_c = temperature_k - 273.15
+    vapor_pressure = 611.2 * math.exp(17.67 * temperature_c / (temperature_c + 243.5))
+    vapor_pressure = min(vapor_pressure, 0.99 * pressure_pa)
+    return 1_000.0 * 0.622 * vapor_pressure / max(pressure_pa - vapor_pressure, 1.0)
+
+
+def _interpolated_level(
+    levels: list[TradeCumulusProfileLevel],
+    height_m: float,
+) -> TradeCumulusProfileLevel:
+    if height_m <= levels[0].height_m:
+        return levels[0]
+    for lower, upper in zip(levels, levels[1:], strict=False):
+        if lower.height_m <= height_m <= upper.height_m:
+            if math.isclose(lower.height_m, upper.height_m):
+                return lower
+            fraction = (height_m - lower.height_m) / (upper.height_m - lower.height_m)
+            values = {
+                key: getattr(lower, key) + fraction * (getattr(upper, key) - getattr(lower, key))
+                for key in (
+                    "pressure_pa",
+                    "theta_l_k",
+                    "total_water_g_kg",
+                    "relative_humidity_percent",
+                    "u_m_s",
+                    "v_m_s",
+                )
+            }
+            return TradeCumulusProfileLevel(height_m=height_m, **values)
+    return levels[-1]
+
+
+def _layer_mean(points: list[tuple[float, float]], lower: float, upper: float) -> float:
+    if upper <= lower:
+        return math.nan
+    ordered = sorted(points)
+    clipped = [(lower, _interpolate_points(ordered, lower))]
+    clipped.extend((height, value) for height, value in ordered if lower < height < upper)
+    clipped.append((upper, _interpolate_points(ordered, upper)))
+    integral = sum(
+        0.5 * (left[1] + right[1]) * (right[0] - left[0])
+        for left, right in zip(clipped, clipped[1:], strict=False)
+    )
+    return integral / (upper - lower)
+
+
+def _interpolate_points(points: list[tuple[float, float]], height: float) -> float:
+    if height <= points[0][0]:
+        return points[0][1]
+    for lower, upper in zip(points, points[1:], strict=False):
+        if lower[0] <= height <= upper[0]:
+            fraction = (height - lower[0]) / max(upper[0] - lower[0], 1.0e-12)
+            return lower[1] + fraction * (upper[1] - lower[1])
+    return points[-1][1]
+
+
+def _signed_extreme(values: list[float]) -> float:
+    return max(values, key=abs)
+
+
+def _minimum_theta_gradient(levels: list[TradeCumulusProfileLevel]) -> float:
+    gradients = [
+        (upper.theta_l_k - lower.theta_l_k)
+        / max(upper.height_m - lower.height_m, 1.0e-12)
+        * 1_000.0
+        for lower, upper in zip(levels, levels[1:], strict=False)
+    ]
+    return min(gradients)
+
+
+def _label(key: str) -> str:
+    return _DIFFERENCE_METADATA[key][1]
+
+
+_DIFFERENCE_METADATA: dict[str, tuple[Any, str, str]] = {
+    "surface_sensible_heat_flux_k_m_s": (
+        "forcing_initiation",
+        "Surface sensible heat flux",
+        "K m s^-1",
+    ),
+    "surface_moisture_flux_g_kg_m_s": (
+        "forcing_initiation",
+        "Surface moisture flux",
+        "g kg^-1 m s^-1",
+    ),
+    "sub_inversion_total_water_g_kg": (
+        "moisture",
+        "Sub-inversion total water",
+        "g kg^-1",
+    ),
+    "inversion_base_m_agl": ("stability_thermodynamics", "Inversion base", "m AGL"),
+    "inversion_thickness_m": ("stability_thermodynamics", "Inversion thickness", "m"),
+    "inversion_strength_k": ("stability_thermodynamics", "Inversion strength", "K"),
+    "free_tropospheric_rh_percent": (
+        "moisture",
+        "Free-tropospheric humidity",
+        "%",
+    ),
+    "cloud_layer_shear_m_s": ("wind", "0-3 km vector shear", "m s^-1"),
+    "cloud_layer_shear_direction_deg": ("wind", "Shear direction", "deg"),
+    "cloud_layer_mean_u_m_s": ("wind", "0-3 km mean u wind", "m s^-1"),
+    "cloud_layer_mean_v_m_s": ("wind", "0-3 km mean v wind", "m s^-1"),
+    "large_scale_vertical_motion_m_s": (
+        "forcing_initiation",
+        "Large-scale vertical motion",
+        "m s^-1",
+    ),
+    "temperature_tendency_k_day": (
+        "forcing_initiation",
+        "Temperature tendency",
+        "K day^-1",
+    ),
+    "total_water_tendency_g_kg_day": (
+        "forcing_initiation",
+        "Total-water tendency",
+        "g kg^-1 day^-1",
+    ),
+}

--- a/app/backend/cloud_chamber/trade_cumulus_recipes.py
+++ b/app/backend/cloud_chamber/trade_cumulus_recipes.py
@@ -34,7 +34,7 @@ class TradeCumulusControls(BaseModel):
     sub_inversion_total_water_g_kg: float = Field(
         default=REFERENCE_SUB_INVERSION_QT_G_KG, ge=0.0, le=25.0
     )
-    inversion_base_m_agl: float = Field(default=520.0, ge=300.0, le=4_000.0)
+    inversion_base_m_agl: float = Field(default=520.0, ge=300.0, le=2_800.0)
     inversion_thickness_m: float = Field(default=960.0, ge=50.0, le=2_000.0)
     inversion_strength_k: float = Field(default=3.7, ge=-5.0, le=20.0)
     free_tropospheric_rh_percent: float = Field(

--- a/app/backend/cloud_chamber/trade_cumulus_recipes.py
+++ b/app/backend/cloud_chamber/trade_cumulus_recipes.py
@@ -83,6 +83,7 @@ class TradeCumulusDiagnostics(BaseModel):
     cloud_layer_mean_v_m_s: float
     initial_saturated_level_count: int
     minimum_theta_gradient_k_km: float
+    surface_heat_to_moisture_ratio_k_per_g_kg: float | None
     labels: list[str]
 
 
@@ -191,6 +192,16 @@ def resolve_trade_cumulus_recipe(
             cloud_layer_mean_v_m_s=achieved["cloud_layer_mean_v_m_s"],
             initial_saturated_level_count=saturated_count,
             minimum_theta_gradient_k_km=minimum_gradient,
+            surface_heat_to_moisture_ratio_k_per_g_kg=(
+                effective.surface_sensible_heat_flux_k_m_s
+                / effective.surface_moisture_flux_g_kg_m_s
+                if not math.isclose(
+                    effective.surface_moisture_flux_g_kg_m_s,
+                    0.0,
+                    abs_tol=1.0e-12,
+                )
+                else None
+            ),
             labels=labels,
         ),
     )
@@ -454,6 +465,8 @@ def _profile_heights(model_top_m: float, inversion_base_m: float) -> list[float]
 
 
 def _model_top(profile: RunCostProfile) -> float:
+    if profile.numerical_realization.exact_domain is not None:
+        return profile.numerical_realization.exact_domain.model_top_m
     grid = profile.numerical_realization.grid.replace(" ", "").split("×")
     spacing = profile.numerical_realization.spacing.replace("about", "").strip().split("×")
     try:

--- a/app/backend/cloud_chamber/trade_cumulus_variations.py
+++ b/app/backend/cloud_chamber/trade_cumulus_variations.py
@@ -145,6 +145,7 @@ class TradeCumulusVariationPreview(BaseModel):
     numerical_realization: dict[str, Any]
     observation_plan: dict[str, Any]
     cost_estimate: RunCostEstimate
+    source_customization_required: bool
 
 
 class TradeCumulusVariationPackage(BaseModel):
@@ -208,6 +209,7 @@ def preview_trade_cumulus_variation(
         ),
         observation_plan=resolved.observation_plan.model_dump(mode="json"),
         cost_estimate=estimate_profile(settings, resolved.resolved_cost_profile),
+        source_customization_required=_forcing_changed(normalize_controls(request.controls)),
     )
 
 
@@ -983,15 +985,15 @@ def _forcing_changed(controls: TradeCumulusControls) -> bool:
 
 
 def _domain_record(profile_id: str) -> dict[str, float]:
-    profile = _PROFILE_REALIZATIONS[profile_id]
+    exact = profile_by_id(profile_id).numerical_realization.exact_domain
+    if exact is None:
+        raise TradeCumulusVariationError(
+            "Trade Cumulus run profile lacks an exact numerical realization."
+        )
     return {
-        "nx": float(profile["nx"]),
-        "ny": float(profile["ny"]),
-        "nz": float(profile["nz"]),
-        "dx_m": float(profile["dx"]),
-        "dy_m": float(profile["dy"]),
-        "dz_m": float(profile["dz"]),
-        "model_top_m": float(profile["nz"]) * float(profile["dz"]),
+        key: float(value)
+        for key, value in exact.model_dump(mode="json").items()
+        if key != "timestep_seconds"
     }
 
 

--- a/app/backend/cloud_chamber/trade_cumulus_variations.py
+++ b/app/backend/cloud_chamber/trade_cumulus_variations.py
@@ -1,0 +1,1100 @@
+"""Durable Trade Cumulus variation envelopes and deterministic packaging."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import shutil
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict
+
+from cloud_chamber import __version__
+from cloud_chamber.bomex_case import (
+    CASE_ID,
+    BomexVariant,
+    collect_cm1_provenance,
+    render_bomex_namelist,
+    replace_bomex_namelist_assignment,
+    sha256_file,
+    verified_clean_git_commit,
+)
+from cloud_chamber.cloud_worlds import (
+    MORE_MOISTURE_SIMULATION_ID,
+    REFERENCE_SIMULATION_ID,
+    SimulationRecord,
+    trade_cumulus_world_detail,
+)
+from cloud_chamber.generated_input_identity import (
+    GeneratedInputIdentityError,
+    verify_generated_input_identity,
+)
+from cloud_chamber.run_cost import (
+    RunCostEstimate,
+    create_launch_review_snapshot,
+    estimate_profile,
+    profile_by_id,
+    profiles,
+)
+from cloud_chamber.run_manifest import (
+    AppMetadata,
+    GeneratedInputs,
+    LifecycleState,
+    ProductState,
+    ProvenanceMetadata,
+    RunManifest,
+    RuntimePaths,
+    ScenarioReference,
+    UserMetadata,
+    ValidationStatus,
+    load_run_manifest,
+    write_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.storage_policy import DEFAULT_STORAGE_WARNING_THRESHOLD_BYTES
+from cloud_chamber.trade_cumulus_forcing import (
+    TRADE_CUMULUS_FORCING_ARTIFACT_FILENAME,
+    TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND,
+    TRADE_CUMULUS_FORCING_TARGET,
+    forcing_customization_artifact,
+    verify_forcing_artifact,
+)
+from cloud_chamber.trade_cumulus_recipes import (
+    RECIPE_CONTRACT_VERSION,
+    RECIPE_ID,
+    RECIPE_NAME,
+    RUN_COST_RECIPE_VERSION,
+    ResolvedTradeCumulusRecipe,
+    TradeCumulusControls,
+    default_controls,
+    normalize_controls,
+    resolve_trade_cumulus_recipe,
+)
+from cloud_chamber.variation_envelope import (
+    AttemptRelationship,
+    VariationAttempt,
+    VariationDifference,
+    VariationEnvelope,
+    VariationValidationDecision,
+    canonical_payload_sha256,
+    classify_relationship,
+    grouped_differences,
+    immutable_layer,
+)
+
+WORLD_ID = "trade_cumulus"
+VARIATION_CASE_ID = "trade_cumulus_recipe_variation_v1"
+VARIATION_SCHEMA_VERSION = "trade_cumulus_variation_v1"
+DEFAULT_PROFILE_ID = "trade_cumulus_standard_v1"
+
+
+class TradeCumulusVariationError(RuntimeError):
+    """Raised when an approved Trade Cumulus variation cannot be represented honestly."""
+
+
+class TradeCumulusVariationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    parent_simulation_id: str = REFERENCE_SIMULATION_ID
+    simulation_name: str
+    user_question: str | None = None
+    recipe_id: str = RECIPE_ID
+    run_profile_id: str = DEFAULT_PROFILE_ID
+    controls: TradeCumulusControls
+
+
+class TradeCumulusVariationTemplate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    parent_simulation_id: str
+    parent_run_id: str
+    parent_display_name: str
+    parent_configuration_source: str
+    reference_simulation_id: str = REFERENCE_SIMULATION_ID
+    recipe_id: str = RECIPE_ID
+    recipe_name: str = RECIPE_NAME
+    recipe_contract_version: str = RECIPE_CONTRACT_VERSION
+    controls: TradeCumulusControls
+    canonical_reference_controls: TradeCumulusControls
+    run_profiles: list[RunCostEstimate]
+    default_run_profile_id: str
+    can_create_variation: bool
+    unavailable_reason: str | None = None
+
+
+class TradeCumulusVariationPreview(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    recipe_id: str = RECIPE_ID
+    recipe_name: str = RECIPE_NAME
+    requested_controls: dict[str, float]
+    resolved_controls: dict[str, float | None]
+    canonical_reference_controls: dict[str, float]
+    parent_controls: dict[str, float]
+    differences: dict[str, list[dict[str, Any]]]
+    relationship_classification: str | None
+    warnings: list[str]
+    blocking_errors: list[str]
+    diagnostics: dict[str, Any]
+    sounding_profile: list[dict[str, Any]]
+    forcing_profile: list[dict[str, Any]]
+    numerical_realization: dict[str, Any]
+    observation_plan: dict[str, Any]
+    cost_estimate: RunCostEstimate
+
+
+class TradeCumulusVariationPackage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    simulation_id: str
+    run_id: str
+    manifest_path: str
+    package_dir: str
+    envelope: VariationEnvelope
+    differences: dict[str, list[dict[str, Any]]]
+    warnings: list[str]
+    preflight: dict[str, Any]
+    launch_review_snapshot_id: str
+
+
+class _VariationContext(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    template: TradeCumulusVariationTemplate
+    parent: SimulationRecord
+    parent_manifest: RunManifest
+    parent_manifest_path: Path
+    parent_controls: TradeCumulusControls
+    parent_profile_id: str
+    parent_numerical_realization: dict[str, Any]
+    parent_observation_plan: dict[str, Any]
+
+
+def trade_cumulus_variation_template(
+    settings: CloudChamberSettings,
+    parent_simulation_id: str,
+) -> TradeCumulusVariationTemplate:
+    return _variation_context(settings, parent_simulation_id).template
+
+
+def preview_trade_cumulus_variation(
+    settings: CloudChamberSettings,
+    request: TradeCumulusVariationRequest,
+) -> TradeCumulusVariationPreview:
+    context = _variation_context(settings, request.parent_simulation_id)
+    resolved, differences = _resolve_request(request, context)
+    errors = _request_errors(request, context, resolved, differences)
+    return TradeCumulusVariationPreview(
+        requested_controls=normalize_controls(request.controls).model_dump(mode="json"),
+        resolved_controls={
+            key: value if math.isfinite(value) else None
+            for key, value in resolved.achieved_controls.items()
+        },
+        canonical_reference_controls=default_controls().model_dump(mode="json"),
+        parent_controls=context.parent_controls.model_dump(mode="json"),
+        differences=grouped_differences(differences),
+        relationship_classification=_relationship(differences),
+        warnings=_dedupe(resolved.warnings),
+        blocking_errors=_dedupe(errors),
+        diagnostics=resolved.diagnostics.model_dump(mode="json"),
+        sounding_profile=[level.model_dump(mode="json") for level in resolved.sounding],
+        forcing_profile=[level.model_dump(mode="json") for level in resolved.forcing_profile],
+        numerical_realization=resolved.resolved_cost_profile.numerical_realization.model_dump(
+            mode="json"
+        ),
+        observation_plan=resolved.observation_plan.model_dump(mode="json"),
+        cost_estimate=estimate_profile(settings, resolved.resolved_cost_profile),
+    )
+
+
+def create_trade_cumulus_variation(
+    settings: CloudChamberSettings,
+    request: TradeCumulusVariationRequest,
+) -> TradeCumulusVariationPackage:
+    context = _variation_context(settings, request.parent_simulation_id)
+    resolved, differences = _resolve_request(request, context)
+    errors = _request_errors(request, context, resolved, differences)
+    if errors:
+        raise TradeCumulusVariationError(" ".join(_dedupe(errors)))
+    implementation_commit = verified_clean_git_commit()
+    provenance = collect_cm1_provenance(settings)
+    controls = normalize_controls(request.controls)
+    numerical_payload = resolved.resolved_cost_profile.numerical_realization.model_dump(mode="json")
+    observation_payload = resolved.observation_plan.model_dump(mode="json")
+    scientific_design: dict[str, Any] = {
+        "world_id": WORLD_ID,
+        "recipe_id": RECIPE_ID,
+        "recipe_contract_version": RECIPE_CONTRACT_VERSION,
+        "reference_simulation_id": REFERENCE_SIMULATION_ID,
+        "controls": controls.model_dump(mode="json"),
+        "achieved_controls": resolved.achieved_controls,
+        "fixed_assumptions": {
+            "case_family": "BOMEX shallow cumulus",
+            "microphysics": "reversible moist thermodynamics without precipitation fallout",
+            "surface_forcing": "spatially uniform signed kinematic fluxes",
+            "large_scale_profile_shapes": "canonical BOMEX piecewise profiles",
+            "initial_profile_path": "consumed external CM1 isnd=7 sounding",
+        },
+    }
+    identity = canonical_payload_sha256(
+        {
+            "scientific_design": scientific_design,
+            "numerical_realization": numerical_payload,
+        }
+    )
+    slug = _slug(request.simulation_name)
+    simulation_id = f"trade_cumulus_{slug}_{identity[:8]}"
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    run_id = f"tc-{slug}-{timestamp}-{uuid4().hex[:4]}"
+    existing_attempts = _existing_attempts(settings, simulation_id)
+    attempt_relationship: AttemptRelationship = (
+        "unchanged_retry" if existing_attempts else "initial"
+    )
+    package_dir = settings.runtime_home.expanduser() / "runs" / run_id
+    if package_dir.exists():
+        raise TradeCumulusVariationError(f"Run package already exists: {run_id}")
+    package_dir.mkdir(parents=True)
+    paths = {
+        "manifest": package_dir / "run_manifest.json",
+        "case_manifest": package_dir / "case_manifest.json",
+        "namelist": package_dir / "namelist.input",
+        "sounding": package_dir / "input_sounding",
+        "runtime_checklist": package_dir / "runtime_file_checklist.json",
+        "package_report": package_dir / "trade_cumulus_variation.json",
+    }
+    forcing_changed = _forcing_changed(controls)
+    if forcing_changed:
+        paths["forcing_customization"] = package_dir / TRADE_CUMULUS_FORCING_ARTIFACT_FILENAME
+    try:
+        reference_namelist = Path(provenance.bundled_bomex_namelist_path).read_text()
+        namelist = _render_namelist(reference_namelist, controls, request.run_profile_id)
+        paths["namelist"].write_text(namelist)
+        paths["sounding"].write_text(_render_sounding(resolved))
+        if forcing_changed:
+            source = (Path(provenance.source_tree_path) / TRADE_CUMULUS_FORCING_TARGET).read_text()
+            _write_json(
+                paths["forcing_customization"],
+                forcing_customization_artifact(
+                    source,
+                    vertical_motion_m_s=controls.large_scale_vertical_motion_m_s,
+                    temperature_tendency_k_day=controls.temperature_tendency_k_day,
+                    total_water_tendency_g_kg_day=controls.total_water_tendency_g_kg_day,
+                ),
+            )
+        _write_json(
+            paths["runtime_checklist"],
+            {
+                "status": (
+                    "external_sounding_and_source_locked_forcing_customization"
+                    if forcing_changed
+                    else "external_sounding_with_canonical_source_forcing"
+                ),
+                "consumed_files": ["input_sounding"],
+                "required_files": ["LANDUSE.TBL"],
+                "source_candidates": {
+                    "LANDUSE.TBL": ["config_files/les_ShallowCu/LANDUSE.TBL", "LANDUSE.TBL"]
+                },
+                "packaged_source_customization": (
+                    TRADE_CUMULUS_FORCING_ARTIFACT_FILENAME if forcing_changed else None
+                ),
+            },
+        )
+        generated_hashes = {
+            path.name: sha256_file(path)
+            for key, path in paths.items()
+            if key
+            in {
+                "namelist",
+                "sounding",
+                "runtime_checklist",
+                "forcing_customization",
+            }
+        }
+        package_identity = canonical_payload_sha256(
+            {
+                "simulation_identity_sha256": identity,
+                "observation_plan": observation_payload,
+                "generated_input_sha256": generated_hashes,
+                "implementation_commit": implementation_commit,
+            }
+        )
+        relationship = classify_relationship(differences)
+        cost_estimate = estimate_profile(settings, resolved.resolved_cost_profile)
+        envelope = VariationEnvelope(
+            world_id=WORLD_ID,
+            recipe_id=RECIPE_ID,
+            recipe_contract_version=RECIPE_CONTRACT_VERSION,
+            simulation_id=simulation_id,
+            parent_simulation_id=context.parent.simulation_id or request.parent_simulation_id,
+            reference_simulation_id=REFERENCE_SIMULATION_ID,
+            display_name=request.simulation_name.strip(),
+            question=_optional_text(request.user_question),
+            scientific_design=immutable_layer(scientific_design),
+            numerical_realization=immutable_layer(numerical_payload),
+            observation_plan=immutable_layer(observation_payload),
+            world_payload={
+                "controls": controls.model_dump(mode="json"),
+                "achieved_controls": resolved.achieved_controls,
+                "sounding": [level.model_dump(mode="json") for level in resolved.sounding],
+                "forcing_profile": [
+                    level.model_dump(mode="json") for level in resolved.forcing_profile
+                ],
+                "diagnostics": resolved.diagnostics.model_dump(mode="json"),
+            },
+            differences=differences,
+            relationship_classification=relationship,
+            run_profile_id=request.run_profile_id,
+            run_profile_contract=resolved.resolved_cost_profile.model_dump(mode="json"),
+            cost_estimate=cost_estimate.model_dump(mode="json"),
+            package_identity_sha256=package_identity,
+            attempts=[
+                *existing_attempts,
+                VariationAttempt(
+                    attempt_id=run_id,
+                    run_id=run_id,
+                    relationship=attempt_relationship,
+                    package_identity_sha256=package_identity,
+                    accepted_backing=False,
+                ),
+            ],
+            validation_decisions=[
+                VariationValidationDecision(
+                    stage="specification",
+                    disposition="passed",
+                    reason=(
+                        "Requested physical targets were generated within declared tolerances."
+                    ),
+                ),
+                VariationValidationDecision(
+                    stage="package",
+                    disposition="pending",
+                    reason="Exact generated-input hashes await package preflight.",
+                ),
+                VariationValidationDecision(
+                    stage="availability",
+                    disposition="pending",
+                    reason="Availability requires complete inspectable native output.",
+                ),
+                VariationValidationDecision(
+                    stage="parent_eligibility",
+                    disposition="pending",
+                    reason="Parent eligibility is distinct from availability.",
+                ),
+            ],
+            availability_state="packaged",
+        )
+        launch_specification = {
+            "world_id": WORLD_ID,
+            "recipe_id": RECIPE_ID,
+            "recipe_version": RUN_COST_RECIPE_VERSION,
+            "profile_id": request.run_profile_id,
+            "numerical_realization": numerical_payload,
+            "observation_plan": observation_payload,
+        }
+        run_configuration: dict[str, Any] = {
+            "cloud_world_id": WORLD_ID,
+            "simulation_id": simulation_id,
+            "simulation_display_name": request.simulation_name.strip(),
+            "attempt_id": run_id,
+            "attempt_relationship": attempt_relationship,
+            "parent_simulation_id": context.parent.simulation_id,
+            "parent_run_id": context.parent.run_id,
+            "parent_result_id": context.parent.result_id,
+            "reference_simulation_id": REFERENCE_SIMULATION_ID,
+            "reference_result_id": (
+                trade_cumulus_world_detail(settings).reference_simulation.result_id
+            ),
+            "source_recipe_id": RECIPE_ID,
+            "user_question": _optional_text(request.user_question),
+            "case_id": CASE_ID,
+            "variation_envelope": envelope.model_dump(mode="json"),
+            "trade_cumulus_configuration": {
+                "controls": controls.model_dump(mode="json"),
+                "achieved_controls": resolved.achieved_controls,
+                "duration_seconds": resolved.observation_plan.duration_seconds,
+                "output_cadence_seconds": resolved.observation_plan.output_cadence_seconds,
+            },
+            "configuration_difference": grouped_differences(differences),
+            "warnings": resolved.warnings,
+            "duration_seconds": resolved.observation_plan.duration_seconds,
+            "output_cadence_seconds": resolved.observation_plan.output_cadence_seconds,
+            "expected_model_output_count": resolved.observation_plan.expected_history_count,
+            "domain": _domain_record(request.run_profile_id),
+            "generated_input_sha256": generated_hashes,
+            "parent_manifest_path": str(context.parent_manifest_path),
+            "cm1_provenance": provenance.model_dump(mode="json"),
+            "launch_specification": launch_specification,
+            "cm1_source_customization_kind": (
+                TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND if forcing_changed else None
+            ),
+        }
+        now = datetime.now(UTC)
+        manifest = RunManifest(
+            run_id=run_id,
+            scenario=ScenarioReference(
+                id=VARIATION_CASE_ID,
+                schema_version=VARIATION_SCHEMA_VERSION,
+            ),
+            controls={
+                key: value
+                for key, value in controls.model_dump(mode="json").items()
+                if isinstance(value, str | float | int | bool)
+            },
+            run_configuration=run_configuration,
+            physical_question=(
+                _optional_text(request.user_question)
+                or f"How does {request.simulation_name.strip()} differ from its parent?"
+            ),
+            expected_diagnostics=[
+                "cloud_liquid_and_cloud_fraction",
+                "vertical_velocity_and_horizontal_wind",
+                "domain_mean_thermodynamic_profiles",
+                "surface_and_large_scale_forcing",
+                "runtime_integrity_and_non_finite_scan",
+            ],
+            generated_inputs=GeneratedInputs(
+                run_directory=str(package_dir),
+                manifest_path=str(paths["manifest"]),
+                namelist_input=str(paths["namelist"]),
+                input_sounding=str(paths["sounding"]),
+                dry_run_report=str(paths["package_report"]),
+                cm1_source_customization=(
+                    str(paths["forcing_customization"]) if forcing_changed else None
+                ),
+                runtime_file_checklist=[str(paths["runtime_checklist"])],
+            ),
+            runtime_paths=RuntimePaths(
+                runtime_home=str(settings.runtime_home.expanduser()),
+                cm1_root=str(settings.cm1_root) if settings.cm1_root else None,
+                cm1_run_dir=str(settings.cm1_run_dir) if settings.cm1_run_dir else None,
+                cache_dir=str(settings.cache_dir),
+                log_dir=str(settings.log_dir),
+            ),
+            app=AppMetadata(app_version=__version__, commit=implementation_commit),
+            lifecycle_state=LifecycleState.PACKAGED,
+            validation_status=ValidationStatus.NEEDS_REVIEW,
+            provenance=ProvenanceMetadata(product_state=ProductState.PACKAGED_DRY_RUN_OUTPUT),
+            created_at=now,
+            updated_at=now,
+            user=UserMetadata(
+                name=request.simulation_name.strip(),
+                notes=_optional_text(request.user_question),
+            ),
+            pre_run_validation_report={
+                "status": "passed",
+                "blocking_errors": [],
+                "caveats": resolved.warnings,
+                "relationship_classification": relationship,
+                "configuration_difference": grouped_differences(differences),
+                "target_achievement": resolved.achieved_controls,
+                "package_path": "shared_variation_envelope_v1",
+            },
+            run_recipe=RECIPE_ID,
+            run_recipe_display_name=RECIPE_NAME,
+            recipe_id=RECIPE_ID,
+            recipe_display_name=RECIPE_NAME,
+            assumption_set_id=f"{RECIPE_ID}_contract_v1",
+            assumption_mode="approved_recipe_contract",
+            recipe_assumptions=scientific_design["fixed_assumptions"],
+            required_output_fields=list(resolved.observation_plan.retained_field_inventory),
+            input_source="source_locked_bomex_external_profile_transform_v1",
+            expected_outputs=["native_numbered_cm1_model_netcdf", "cm1_stats_and_logs"],
+            run_caveats=resolved.warnings,
+            manual_validation_status="approved_recipe_variation_packaged",
+        )
+        write_run_manifest(paths["manifest"], manifest)
+        case_manifest: dict[str, Any] = {
+            "schema_version": VARIATION_SCHEMA_VERSION,
+            "variation_envelope_authority": {
+                "manifest_path": str(paths["manifest"]),
+                "run_configuration_key": "variation_envelope",
+                "schema_version": envelope.schema_version,
+            },
+            "implementation_commit": implementation_commit,
+            "run_id": run_id,
+            "generated_input_sha256": generated_hashes,
+            "target_achievement": resolved.achieved_controls,
+            "cm1_provenance": provenance.model_dump(mode="json"),
+        }
+        _write_json(paths["case_manifest"], case_manifest)
+        _write_json(paths["package_report"], {"status": "packaged_not_queued", **case_manifest})
+        preflight = preflight_trade_cumulus_variation(paths["manifest"])
+        envelope.validation_decisions[1] = VariationValidationDecision(
+            stage="package",
+            disposition="passed",
+            reason="Exact generated-input hashes and package preflight passed.",
+        )
+        manifest = load_run_manifest(paths["manifest"])
+        run_configuration["variation_envelope"] = envelope.model_dump(mode="json")
+        manifest.run_configuration = run_configuration
+        manifest.updated_at = datetime.now(UTC)
+        write_run_manifest(paths["manifest"], manifest)
+        snapshot = create_launch_review_snapshot(
+            settings,
+            profile_id=request.run_profile_id,
+            warning_threshold_bytes=DEFAULT_STORAGE_WARNING_THRESHOLD_BYTES,
+            manifest=manifest,
+            resolved_profile=resolved.resolved_cost_profile,
+        )
+        snapshot_id = snapshot.snapshot.snapshot_id
+        envelope.launch_review_snapshot_id = snapshot_id
+        run_configuration["launch_review_snapshot_id"] = snapshot_id
+        run_configuration["variation_envelope"] = envelope.model_dump(mode="json")
+        manifest.run_configuration = run_configuration
+        manifest.updated_at = datetime.now(UTC)
+        write_run_manifest(paths["manifest"], manifest)
+        case_manifest["launch_review_snapshot_id"] = snapshot_id
+        _write_json(paths["case_manifest"], case_manifest)
+        _write_json(paths["package_report"], {"status": "packaged_not_queued", **case_manifest})
+        return TradeCumulusVariationPackage(
+            simulation_id=simulation_id,
+            run_id=run_id,
+            manifest_path=str(paths["manifest"]),
+            package_dir=str(package_dir),
+            envelope=envelope,
+            differences=grouped_differences(differences),
+            warnings=resolved.warnings,
+            preflight=preflight,
+            launch_review_snapshot_id=snapshot_id,
+        )
+    except Exception:
+        shutil.rmtree(package_dir, ignore_errors=True)
+        raise
+
+
+def preflight_trade_cumulus_variation(manifest_path: Path) -> dict[str, Any]:
+    manifest = load_run_manifest(manifest_path.expanduser())
+    if manifest.lifecycle_state != LifecycleState.PACKAGED:
+        raise TradeCumulusVariationError("Variation preflight requires a packaged manifest.")
+    if manifest.run_configuration.get("cloud_world_id") != WORLD_ID:
+        raise TradeCumulusVariationError("Variation manifest does not belong to Trade Cumulus.")
+    envelope = _manifest_envelope(manifest)
+    try:
+        controls = normalize_controls(
+            TradeCumulusControls.model_validate(envelope.world_payload.get("controls"))
+        )
+        profile = profile_by_id(envelope.run_profile_id)
+        resolved = resolve_trade_cumulus_recipe(
+            controls=controls,
+            parent_controls=controls,
+            catalog_profile=profile,
+        )
+    except (ValueError, TypeError) as exc:
+        raise TradeCumulusVariationError(
+            "Variation package does not resolve through the declared Recipe contract."
+        ) from exc
+    run_dir = Path(manifest.generated_inputs.run_directory).expanduser()
+    required = [
+        run_dir / "namelist.input",
+        run_dir / "input_sounding",
+        run_dir / "runtime_file_checklist.json",
+        run_dir / "case_manifest.json",
+    ]
+    customization = manifest.generated_inputs.cm1_source_customization
+    if customization:
+        required.append(Path(customization).expanduser())
+    missing = [path.name for path in required if not path.is_file()]
+    outputs = sorted(path.name for path in run_dir.glob("cm1out*") if path.is_file())
+    try:
+        verified_hashes = verify_generated_input_identity(manifest)
+    except GeneratedInputIdentityError:
+        verified_hashes = {}
+    source_customization_valid = True
+    if customization:
+        provenance = manifest.run_configuration.get("cm1_provenance")
+        source_root = (
+            Path(str(provenance.get("source_tree_path")))
+            if isinstance(provenance, dict)
+            else Path()
+        )
+        source_path = source_root / TRADE_CUMULUS_FORCING_TARGET
+        try:
+            verify_forcing_artifact(Path(customization), source_path.read_text())
+        except (OSError, ValueError):
+            source_customization_valid = False
+    namelist_text = (run_dir / "namelist.input").read_text()
+    sounding_text = (run_dir / "input_sounding").read_text()
+    expected_namelist = {
+        **_PROFILE_REALIZATIONS[envelope.run_profile_id],
+        "isnd": 7,
+        "iwnd": 0,
+        "cnst_shflx": controls.surface_sensible_heat_flux_k_m_s,
+        "cnst_lhflx": controls.surface_moisture_flux_g_kg_m_s / 1_000.0,
+    }
+    namelist_readback = {name: _namelist_number(namelist_text, name) for name in expected_namelist}
+    namelist_matches = all(
+        value is not None
+        and math.isclose(
+            value,
+            float(expected),
+            rel_tol=1.0e-10,
+            abs_tol=1.0e-12,
+        )
+        for (name, expected), value in zip(
+            expected_namelist.items(), namelist_readback.values(), strict=True
+        )
+    )
+    expected_observation = resolved.observation_plan.model_dump(mode="json")
+    declared_observation = envelope.observation_plan.payload
+    declared_domain = manifest.run_configuration.get("domain")
+    expected_domain = _domain_record(envelope.run_profile_id)
+    checks = {
+        "packaged_manifest": True,
+        "shared_envelope": envelope.schema_version == "cloud_world_variation_v1",
+        "required_inputs_present": not missing,
+        "generated_hashes_match": bool(verified_hashes),
+        "no_existing_cm1_output": not outputs,
+        "external_sounding_consumed": namelist_readback["isnd"] == 7,
+        "namelist_matches_reviewed_contract": namelist_matches,
+        "sounding_matches_reviewed_contract": sounding_text == _render_sounding(resolved),
+        "achieved_targets_match_review": envelope.world_payload.get("achieved_controls")
+        == resolved.achieved_controls,
+        "observation_plan_matches_review": declared_observation == expected_observation,
+        "domain_matches_review": declared_domain == expected_domain,
+        "required_fields_match_review": manifest.required_output_fields
+        == list(resolved.observation_plan.retained_field_inventory),
+        "expected_histories_match_review": manifest.run_configuration.get(
+            "expected_model_output_count"
+        )
+        == resolved.observation_plan.expected_history_count,
+        "source_customization_valid": source_customization_valid,
+        "launch_specification_bound": isinstance(
+            manifest.run_configuration.get("launch_specification"), dict
+        ),
+    }
+    if not all(checks.values()):
+        raise TradeCumulusVariationError(
+            "Variation package preflight failed: "
+            f"checks={checks}, missing={missing}, outputs={outputs}"
+        )
+    return {
+        "passed": True,
+        "checks": checks,
+        "missing": missing,
+        "existing_outputs": outputs,
+        "generated_hash_checks": {key: True for key in verified_hashes},
+        "namelist_readback": namelist_readback,
+    }
+
+
+def _variation_context(
+    settings: CloudChamberSettings,
+    parent_simulation_id: str,
+) -> _VariationContext:
+    world = trade_cumulus_world_detail(settings)
+    parent = next(
+        (
+            simulation
+            for simulation in world.simulations
+            if simulation.simulation_id == parent_simulation_id
+        ),
+        None,
+    )
+    if parent is None:
+        raise ValueError(f"Trade Cumulus Simulation {parent_simulation_id} was not found.")
+    manifest_path = (
+        settings.runtime_home.expanduser() / "runs" / parent.run_id / "run_manifest.json"
+    )
+    if not manifest_path.is_file():
+        raise TradeCumulusVariationError("The selected parent manifest is unavailable.")
+    manifest = load_run_manifest(manifest_path)
+    parent_controls = _parent_controls(parent, manifest)
+    parent_profile_id = _parent_profile_id(parent, manifest)
+    recipe_profiles = [
+        profile
+        for profile in profiles()
+        if profile.world_id == WORLD_ID and profile.recipe_id == RECIPE_ID
+    ]
+    estimates = [estimate_profile(settings, profile) for profile in recipe_profiles]
+    parent_profile = profile_by_id(parent_profile_id)
+    parent_resolved = resolve_trade_cumulus_recipe(
+        controls=parent_controls,
+        parent_controls=parent_controls,
+        catalog_profile=parent_profile,
+    )
+    parent_numerical, parent_observation = _parent_layers(
+        manifest,
+        parent_resolved.resolved_cost_profile.numerical_realization.model_dump(mode="json"),
+        parent_resolved.observation_plan.model_dump(mode="json"),
+    )
+    can_create, unavailable_reason = _parent_eligibility(parent, manifest)
+    template = TradeCumulusVariationTemplate(
+        parent_simulation_id=parent.simulation_id or parent_simulation_id,
+        parent_run_id=parent.run_id,
+        parent_display_name=parent.display_name,
+        parent_configuration_source=(
+            "retained Recipe controls resolved against the canonical BOMEX reference"
+            if parent.role == "variation"
+            and parent.simulation_id
+            not in {
+                MORE_MOISTURE_SIMULATION_ID,
+            }
+            else "retained canonical BOMEX source-backed atmosphere and forcing"
+        ),
+        controls=parent_controls,
+        canonical_reference_controls=default_controls(),
+        run_profiles=estimates,
+        default_run_profile_id=(
+            parent_profile_id
+            if parent_profile_id in {profile.profile_id for profile in recipe_profiles}
+            else DEFAULT_PROFILE_ID
+        ),
+        can_create_variation=can_create,
+        unavailable_reason=unavailable_reason,
+    )
+    return _VariationContext(
+        template=template,
+        parent=parent,
+        parent_manifest=manifest,
+        parent_manifest_path=manifest_path,
+        parent_controls=parent_controls,
+        parent_profile_id=parent_profile_id,
+        parent_numerical_realization=parent_numerical,
+        parent_observation_plan=parent_observation,
+    )
+
+
+def _resolve_request(
+    request: TradeCumulusVariationRequest,
+    context: _VariationContext,
+) -> tuple[ResolvedTradeCumulusRecipe, list[VariationDifference]]:
+    if request.recipe_id != RECIPE_ID:
+        raise TradeCumulusVariationError("The selected parent and Recipe do not match.")
+    try:
+        profile = profile_by_id(request.run_profile_id)
+    except ValueError as exc:
+        raise TradeCumulusVariationError(str(exc)) from exc
+    resolved = resolve_trade_cumulus_recipe(
+        controls=request.controls,
+        parent_controls=context.parent_controls,
+        catalog_profile=profile,
+    )
+    differences = list(resolved.differences)
+    numerical = resolved.resolved_cost_profile.numerical_realization.model_dump(mode="json")
+    observation = resolved.observation_plan.model_dump(mode="json")
+    if numerical != context.parent_numerical_realization:
+        differences.append(
+            VariationDifference(
+                category="numerical_realization",
+                path="numerical_realization",
+                label="Numerical realization",
+                before=context.parent_numerical_realization,
+                after=numerical,
+            )
+        )
+    if observation != context.parent_observation_plan:
+        differences.append(
+            VariationDifference(
+                category="observation_plan",
+                path="observation_plan",
+                label="Observation plan",
+                before=context.parent_observation_plan,
+                after=observation,
+            )
+        )
+    return resolved, differences
+
+
+def _request_errors(
+    request: TradeCumulusVariationRequest,
+    context: _VariationContext,
+    resolved: ResolvedTradeCumulusRecipe,
+    differences: list[VariationDifference],
+) -> list[str]:
+    errors = list(resolved.blocking_errors)
+    if not context.template.can_create_variation:
+        errors.append(context.template.unavailable_reason or "The selected parent is not eligible.")
+    name = request.simulation_name.strip()
+    if not name:
+        errors.append("A Simulation name is required before packaging.")
+    elif len(name) > 80:
+        errors.append("Simulation names must be 80 characters or fewer.")
+    material = [
+        difference
+        for difference in differences
+        if difference.material and difference.category != "observation_plan"
+    ]
+    if not material:
+        if any(difference.category == "observation_plan" for difference in differences):
+            errors.append(
+                "Changing only the observation plan creates another attempt beneath the "
+                "same Simulation, not a new Variation."
+            )
+        else:
+            errors.append("Change at least one effective Recipe or numerical control.")
+    return errors
+
+
+def _parent_controls(
+    parent: SimulationRecord,
+    manifest: RunManifest,
+) -> TradeCumulusControls:
+    payload = manifest.run_configuration.get("variation_envelope")
+    if isinstance(payload, dict):
+        world_payload = payload.get("world_payload")
+        if isinstance(world_payload, dict) and isinstance(world_payload.get("controls"), dict):
+            try:
+                return normalize_controls(
+                    TradeCumulusControls.model_validate(world_payload["controls"])
+                )
+            except ValueError:
+                pass
+    controls = default_controls().model_dump(mode="json")
+    if parent.simulation_id == MORE_MOISTURE_SIMULATION_ID:
+        controls["surface_moisture_flux_g_kg_m_s"] = 0.078
+    return TradeCumulusControls.model_validate(controls)
+
+
+def _parent_profile_id(parent: SimulationRecord, manifest: RunManifest) -> str:
+    payload = manifest.run_configuration.get("variation_envelope")
+    if isinstance(payload, dict) and isinstance(payload.get("run_profile_id"), str):
+        return str(payload["run_profile_id"])
+    if "presentation" in parent.run_id:
+        return "trade_cumulus_presentation_v1"
+    return "trade_cumulus_full_cycle_v1"
+
+
+def _parent_layers(
+    manifest: RunManifest,
+    fallback_numerical: dict[str, Any],
+    fallback_observation: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    try:
+        envelope = _manifest_envelope(manifest)
+    except TradeCumulusVariationError:
+        return fallback_numerical, fallback_observation
+    return envelope.numerical_realization.payload, envelope.observation_plan.payload
+
+
+def _parent_eligibility(
+    parent: SimulationRecord,
+    manifest: RunManifest,
+) -> tuple[bool, str | None]:
+    if parent.technical_state != "available" or not parent.explore_available:
+        return False, "Only an available, inspectable Simulation can parent a variation."
+    if parent.simulation_id in {REFERENCE_SIMULATION_ID, MORE_MOISTURE_SIMULATION_ID}:
+        return True, None
+    try:
+        envelope = _manifest_envelope(manifest)
+    except TradeCumulusVariationError:
+        return (
+            False,
+            "This inspectable Simulation predates the shared Recipe envelope and cannot "
+            "parent a new variation.",
+        )
+    if not envelope.parent_eligible:
+        return False, envelope.parent_eligibility_reason
+    return True, None
+
+
+def _manifest_envelope(manifest: RunManifest) -> VariationEnvelope:
+    payload = manifest.run_configuration.get("variation_envelope")
+    if not isinstance(payload, dict):
+        raise TradeCumulusVariationError("This variation predates the shared Recipe envelope.")
+    try:
+        envelope = VariationEnvelope.model_validate(payload)
+    except ValueError as exc:
+        raise TradeCumulusVariationError("Variation envelope is invalid.") from exc
+    if envelope.world_id != WORLD_ID or envelope.recipe_id != RECIPE_ID:
+        raise TradeCumulusVariationError("Variation envelope has the wrong World or Recipe.")
+    return envelope
+
+
+def _existing_attempts(
+    settings: CloudChamberSettings,
+    simulation_id: str,
+) -> list[VariationAttempt]:
+    runs_dir = settings.runtime_home.expanduser() / "runs"
+    if not runs_dir.exists():
+        return []
+    attempts: dict[str, tuple[str, VariationAttempt]] = {}
+    for manifest_path in runs_dir.glob("*/run_manifest.json"):
+        try:
+            manifest = load_run_manifest(manifest_path)
+        except (OSError, ValueError):
+            continue
+        if (
+            manifest.run_configuration.get("cloud_world_id") != WORLD_ID
+            or manifest.run_configuration.get("simulation_id") != simulation_id
+        ):
+            continue
+        envelope = _manifest_envelope(manifest)
+        declared = next(
+            (attempt for attempt in envelope.attempts if attempt.run_id == manifest.run_id),
+            None,
+        )
+        if declared is not None:
+            attempts[manifest.run_id] = (manifest.created_at.isoformat(), declared)
+    ordered = [attempt for _created, attempt in sorted(attempts.values())]
+    accepted = [attempt for attempt in ordered if attempt.accepted_backing]
+    if len(accepted) > 1:
+        raise TradeCumulusVariationError(
+            "Existing attempts contain conflicting accepted-backing claims."
+        )
+    return ordered
+
+
+def _render_namelist(
+    reference_text: str,
+    controls: TradeCumulusControls,
+    profile_id: str,
+) -> str:
+    profile = _PROFILE_REALIZATIONS[profile_id]
+    rendered = render_bomex_namelist(reference_text, BomexVariant.FULL)
+    replacements = {
+        **{key: str(value) for key, value in profile.items()},
+        "isnd": "7",
+        "iwnd": "0",
+        "cnst_shflx": _scientific(controls.surface_sensible_heat_flux_k_m_s),
+        "cnst_lhflx": _scientific(controls.surface_moisture_flux_g_kg_m_s / 1_000.0),
+    }
+    for name, value in replacements.items():
+        rendered = replace_bomex_namelist_assignment(rendered, name, value)
+    return rendered.rstrip() + "\n"
+
+
+def _render_sounding(resolved: ResolvedTradeCumulusRecipe) -> str:
+    surface = resolved.sounding[0]
+    lines = [
+        f"{surface.pressure_pa / 100.0:.4f} {surface.theta_l_k:.6f} {surface.total_water_g_kg:.9f}"
+    ]
+    lines.extend(
+        f"{level.height_m:.1f} {level.theta_l_k:.6f} "
+        f"{level.total_water_g_kg:.9f} {level.u_m_s:.6f} {level.v_m_s:.6f}"
+        for level in resolved.sounding
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _forcing_changed(controls: TradeCumulusControls) -> bool:
+    reference = default_controls()
+    return any(
+        not math.isclose(getattr(controls, field), getattr(reference, field), abs_tol=1.0e-12)
+        for field in (
+            "large_scale_vertical_motion_m_s",
+            "temperature_tendency_k_day",
+            "total_water_tendency_g_kg_day",
+        )
+    )
+
+
+def _domain_record(profile_id: str) -> dict[str, float]:
+    profile = _PROFILE_REALIZATIONS[profile_id]
+    return {
+        "nx": float(profile["nx"]),
+        "ny": float(profile["ny"]),
+        "nz": float(profile["nz"]),
+        "dx_m": float(profile["dx"]),
+        "dy_m": float(profile["dy"]),
+        "dz_m": float(profile["dz"]),
+        "model_top_m": float(profile["nz"]) * float(profile["dz"]),
+    }
+
+
+def _namelist_assignment(text: str, name: str) -> str | None:
+    match = re.search(rf"(?m)^\s*{re.escape(name)}\s*=\s*([^,!/]+)", text)
+    return match.group(1).strip() if match else None
+
+
+def _namelist_number(text: str, name: str) -> float | None:
+    value = _namelist_assignment(text, name)
+    if value is None:
+        return None
+    try:
+        return float(value.replace("d", "e").replace("D", "E"))
+    except ValueError:
+        return None
+
+
+def _relationship(differences: list[VariationDifference]) -> str | None:
+    try:
+        return classify_relationship(differences)
+    except ValueError:
+        return None
+
+
+def _slug(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+    return normalized[:48] or "variation"
+
+
+def _optional_text(value: str | None) -> str | None:
+    stripped = value.strip() if value else ""
+    return stripped or None
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(values))
+
+
+def _scientific(value: float) -> str:
+    if value == 0.0:
+        return "0.0"
+    return f"{value:.12e}"
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+_PROFILE_REALIZATIONS: dict[str, dict[str, int | float]] = {
+    "trade_cumulus_quick_v1": {
+        "nx": 64,
+        "ny": 64,
+        "nz": 75,
+        "dx": 100,
+        "dy": 100,
+        "dz": 40,
+        "dtl": 3,
+        "timax": 10_800,
+        "tapfrq": 180,
+    },
+    "trade_cumulus_standard_v1": {
+        "nx": 64,
+        "ny": 64,
+        "nz": 75,
+        "dx": 100,
+        "dy": 100,
+        "dz": 40,
+        "dtl": 3,
+        "timax": 14_400,
+        "tapfrq": 120,
+    },
+    "trade_cumulus_full_cycle_v1": {
+        "nx": 64,
+        "ny": 64,
+        "nz": 75,
+        "dx": 100,
+        "dy": 100,
+        "dz": 40,
+        "dtl": 3,
+        "timax": 21_600,
+        "tapfrq": 120,
+    },
+    "trade_cumulus_presentation_v1": {
+        "nx": 96,
+        "ny": 96,
+        "nz": 100,
+        "dx": 66.66666667,
+        "dy": 66.66666667,
+        "dz": 30,
+        "dtl": 2,
+        "timax": 14_400,
+        "tapfrq": 60,
+    },
+    "trade_cumulus_extended_v1": {
+        "nx": 128,
+        "ny": 128,
+        "nz": 75,
+        "dx": 100,
+        "dy": 100,
+        "dz": 40,
+        "dtl": 3,
+        "timax": 14_400,
+        "tapfrq": 120,
+    },
+}

--- a/app/backend/cloud_chamber/trade_cumulus_variations.py
+++ b/app/backend/cloud_chamber/trade_cumulus_variations.py
@@ -8,7 +8,7 @@ import re
 import shutil
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict
@@ -35,6 +35,7 @@ from cloud_chamber.generated_input_identity import (
 )
 from cloud_chamber.run_cost import (
     RunCostEstimate,
+    RunCostProfile,
     create_launch_review_snapshot,
     estimate_profile,
     profile_by_id,
@@ -63,6 +64,10 @@ from cloud_chamber.trade_cumulus_forcing import (
     forcing_customization_artifact,
     verify_forcing_artifact,
 )
+from cloud_chamber.trade_cumulus_forcing_diagnostics import (
+    FORCING_DIAGNOSTIC_CADENCE_SECONDS,
+    forcing_diagnostic_contract,
+)
 from cloud_chamber.trade_cumulus_recipes import (
     RECIPE_CONTRACT_VERSION,
     RECIPE_ID,
@@ -90,6 +95,10 @@ WORLD_ID = "trade_cumulus"
 VARIATION_CASE_ID = "trade_cumulus_recipe_variation_v1"
 VARIATION_SCHEMA_VERSION = "trade_cumulus_variation_v1"
 DEFAULT_PROFILE_ID = "trade_cumulus_standard_v1"
+EXTENDED_PROFILE_ID = "trade_cumulus_extended_v1"
+EXTENDED_CHARACTERIZATION_AUTHORIZATION_ID: Literal[
+    "issue-448-extended-reference-characterization-v1"
+] = "issue-448-extended-reference-characterization-v1"
 
 
 class TradeCumulusVariationError(RuntimeError):
@@ -105,6 +114,14 @@ class TradeCumulusVariationRequest(BaseModel):
     recipe_id: str = RECIPE_ID
     run_profile_id: str = DEFAULT_PROFILE_ID
     controls: TradeCumulusControls
+
+
+class TradeCumulusExtendedCharacterizationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authorization_id: Literal["issue-448-extended-reference-characterization-v1"] = (
+        EXTENDED_CHARACTERIZATION_AUTHORIZATION_ID
+    )
 
 
 class TradeCumulusVariationTemplate(BaseModel):
@@ -217,8 +234,46 @@ def create_trade_cumulus_variation(
     settings: CloudChamberSettings,
     request: TradeCumulusVariationRequest,
 ) -> TradeCumulusVariationPackage:
+    return _create_trade_cumulus_variation(settings, request)
+
+
+def create_trade_cumulus_extended_characterization(
+    settings: CloudChamberSettings,
+    request: TradeCumulusExtendedCharacterizationRequest,
+) -> TradeCumulusVariationPackage:
+    authorization = _extended_characterization_authorization(request.authorization_id)
+    _require_unused_characterization_authorization(settings, request.authorization_id)
+    characterization_request = TradeCumulusVariationRequest(
+        parent_simulation_id=REFERENCE_SIMULATION_ID,
+        simulation_name="Extended reference characterization",
+        user_question=(
+            "What runtime and retained-storage cost does the exact Extended "
+            "wide-domain reference configuration require?"
+        ),
+        run_profile_id=EXTENDED_PROFILE_ID,
+        controls=default_controls(),
+    )
+    return _create_trade_cumulus_variation(
+        settings,
+        characterization_request,
+        profile_override=_authorized_extended_profile(),
+        characterization_authorization=authorization,
+    )
+
+
+def _create_trade_cumulus_variation(
+    settings: CloudChamberSettings,
+    request: TradeCumulusVariationRequest,
+    *,
+    profile_override: RunCostProfile | None = None,
+    characterization_authorization: dict[str, Any] | None = None,
+) -> TradeCumulusVariationPackage:
     context = _variation_context(settings, request.parent_simulation_id)
-    resolved, differences = _resolve_request(request, context)
+    resolved, differences = _resolve_request(
+        request,
+        context,
+        profile_override=profile_override,
+    )
     errors = _request_errors(request, context, resolved, differences)
     if errors:
         raise TradeCumulusVariationError(" ".join(_dedupe(errors)))
@@ -227,6 +282,16 @@ def create_trade_cumulus_variation(
     controls = normalize_controls(request.controls)
     numerical_payload = resolved.resolved_cost_profile.numerical_realization.model_dump(mode="json")
     observation_payload = resolved.observation_plan.model_dump(mode="json")
+    exact_numerical = resolved.resolved_cost_profile.numerical_realization.exact_domain
+    duration_seconds = resolved.observation_plan.duration_seconds
+    if exact_numerical is None or duration_seconds is None:
+        raise TradeCumulusVariationError(
+            "Trade Cumulus packaging requires an exact numerical and observation realization."
+        )
+    forcing_diagnostics = forcing_diagnostic_contract(
+        duration_seconds=duration_seconds,
+        numerical=exact_numerical,
+    )
     scientific_design: dict[str, Any] = {
         "world_id": WORLD_ID,
         "recipe_id": RECIPE_ID,
@@ -242,6 +307,8 @@ def create_trade_cumulus_variation(
             "initial_profile_path": "consumed external CM1 isnd=7 sounding",
         },
     }
+    if characterization_authorization is not None:
+        scientific_design["characterization_authorization"] = characterization_authorization
     identity = canonical_payload_sha256(
         {
             "scientific_design": scientific_design,
@@ -346,6 +413,8 @@ def create_trade_cumulus_variation(
                     level.model_dump(mode="json") for level in resolved.forcing_profile
                 ],
                 "diagnostics": resolved.diagnostics.model_dump(mode="json"),
+                "forcing_diagnostic_contract": forcing_diagnostics,
+                "characterization_authorization": characterization_authorization,
             },
             differences=differences,
             relationship_classification=relationship,
@@ -430,6 +499,8 @@ def create_trade_cumulus_variation(
             "parent_manifest_path": str(context.parent_manifest_path),
             "cm1_provenance": provenance.model_dump(mode="json"),
             "launch_specification": launch_specification,
+            "forcing_diagnostic_contract": forcing_diagnostics,
+            "characterization_authorization": characterization_authorization,
             "cm1_source_customization_kind": (
                 TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND if forcing_changed else None
             ),
@@ -504,9 +575,27 @@ def create_trade_cumulus_variation(
             recipe_assumptions=scientific_design["fixed_assumptions"],
             required_output_fields=list(resolved.observation_plan.retained_field_inventory),
             input_source="source_locked_bomex_external_profile_transform_v1",
-            expected_outputs=["native_numbered_cm1_model_netcdf", "cm1_stats_and_logs"],
-            run_caveats=resolved.warnings,
-            manual_validation_status="approved_recipe_variation_packaged",
+            expected_outputs=[
+                "native_numbered_cm1_model_netcdf",
+                "cm1_domain_diagnostic_netcdf",
+                "cm1_stats_and_logs",
+            ],
+            run_caveats=[
+                *resolved.warnings,
+                *(
+                    [
+                        "PM-authorized bounded Extended reference characterization; "
+                        "not an ordinary Extended variation."
+                    ]
+                    if characterization_authorization is not None
+                    else []
+                ),
+            ],
+            manual_validation_status=(
+                "pm_authorized_extended_reference_characterization_packaged"
+                if characterization_authorization is not None
+                else "approved_recipe_variation_packaged"
+            ),
         )
         write_run_manifest(paths["manifest"], manifest)
         case_manifest: dict[str, Any] = {
@@ -579,7 +668,7 @@ def preflight_trade_cumulus_variation(manifest_path: Path) -> dict[str, Any]:
         controls = normalize_controls(
             TradeCumulusControls.model_validate(envelope.world_payload.get("controls"))
         )
-        profile = profile_by_id(envelope.run_profile_id)
+        profile = _profile_for_manifest_preflight(manifest, envelope.run_profile_id)
         resolved = resolve_trade_cumulus_recipe(
             controls=controls,
             parent_controls=controls,
@@ -642,6 +731,13 @@ def preflight_trade_cumulus_variation(manifest_path: Path) -> dict[str, Any]:
     )
     expected_observation = resolved.observation_plan.model_dump(mode="json")
     declared_observation = envelope.observation_plan.payload
+    exact_numerical = resolved.resolved_cost_profile.numerical_realization.exact_domain
+    if exact_numerical is None or resolved.observation_plan.duration_seconds is None:
+        raise TradeCumulusVariationError("Variation package lacks an exact diagnostic realization.")
+    expected_forcing_diagnostics = forcing_diagnostic_contract(
+        duration_seconds=resolved.observation_plan.duration_seconds,
+        numerical=exact_numerical,
+    )
     declared_domain = manifest.run_configuration.get("domain")
     expected_domain = _domain_record(envelope.run_profile_id)
     checks = {
@@ -663,6 +759,23 @@ def preflight_trade_cumulus_variation(manifest_path: Path) -> dict[str, Any]:
             "expected_model_output_count"
         )
         == resolved.observation_plan.expected_history_count,
+        "domain_diagnostics_enabled": (
+            (_namelist_assignment(namelist_text, "dodomaindiag") or "").lower() == ".true."
+        ),
+        "diagnostic_cadence_matches_review": math.isclose(
+            _namelist_number(namelist_text, "diagfrq") or -1.0,
+            FORCING_DIAGNOSTIC_CADENCE_SECONDS,
+            rel_tol=0.0,
+            abs_tol=1.0e-12,
+        ),
+        "forcing_diagnostic_contract_matches_review": (
+            envelope.world_payload.get("forcing_diagnostic_contract")
+            == expected_forcing_diagnostics
+            == manifest.run_configuration.get("forcing_diagnostic_contract")
+        ),
+        "forcing_diagnostics_declared_as_output": (
+            "cm1_domain_diagnostic_netcdf" in manifest.expected_outputs
+        ),
         "source_customization_valid": source_customization_valid,
         "launch_specification_bound": isinstance(
             manifest.run_configuration.get("launch_specification"), dict
@@ -763,11 +876,13 @@ def _variation_context(
 def _resolve_request(
     request: TradeCumulusVariationRequest,
     context: _VariationContext,
+    *,
+    profile_override: RunCostProfile | None = None,
 ) -> tuple[ResolvedTradeCumulusRecipe, list[VariationDifference]]:
     if request.recipe_id != RECIPE_ID:
         raise TradeCumulusVariationError("The selected parent and Recipe do not match.")
     try:
-        profile = profile_by_id(request.run_profile_id)
+        profile = profile_override or profile_by_id(request.run_profile_id)
     except ValueError as exc:
         raise TradeCumulusVariationError(str(exc)) from exc
     resolved = resolve_trade_cumulus_recipe(
@@ -799,6 +914,97 @@ def _resolve_request(
             )
         )
     return resolved, differences
+
+
+def _authorized_extended_profile() -> RunCostProfile:
+    profile = profile_by_id(EXTENDED_PROFILE_ID)
+    return profile.model_copy(
+        update={
+            "estimate_basis": "scaled_from_measured",
+            "confidence": (
+                "PM-approved conservative reservation for one bounded characterization, "
+                "scaled from measured Trade Cumulus runs; not characterization evidence."
+            ),
+            "scientific_limitations": [
+                "Authorized only for the exact #448 Extended reference characterization.",
+                "Completion does not enable ordinary Extended variations.",
+            ],
+        }
+    )
+
+
+def _extended_characterization_authorization(
+    authorization_id: str,
+) -> dict[str, Any]:
+    if authorization_id != EXTENDED_CHARACTERIZATION_AUTHORIZATION_ID:
+        raise TradeCumulusVariationError(
+            "Extended characterization requires the exact PM authorization."
+        )
+    return {
+        "schema_version": "trade_cumulus_characterization_authorization_v1",
+        "authorization_id": EXTENDED_CHARACTERIZATION_AUTHORIZATION_ID,
+        "issue_number": 448,
+        "scope": "one_exact_extended_reference_characterization",
+        "profile_id": EXTENDED_PROFILE_ID,
+        "parent_simulation_id": REFERENCE_SIMULATION_ID,
+        "controls": default_controls().model_dump(mode="json"),
+        "maximum_packages": 1,
+        "ordinary_extended_profile_enabled": False,
+    }
+
+
+def _profile_for_manifest_preflight(
+    manifest: RunManifest,
+    profile_id: str,
+) -> RunCostProfile:
+    authorization = manifest.run_configuration.get("characterization_authorization")
+    if authorization is None:
+        return profile_by_id(profile_id)
+    expected = _extended_characterization_authorization(
+        str(authorization.get("authorization_id") if isinstance(authorization, dict) else "")
+    )
+    if (
+        authorization != expected
+        or profile_id != EXTENDED_PROFILE_ID
+        or manifest.run_configuration.get("parent_simulation_id") != REFERENCE_SIMULATION_ID
+    ):
+        raise TradeCumulusVariationError(
+            "Extended characterization package exceeds its exact PM authorization."
+        )
+    envelope = _manifest_envelope(manifest)
+    if (
+        envelope.world_payload.get("characterization_authorization") != expected
+        or normalize_controls(
+            TradeCumulusControls.model_validate(envelope.world_payload.get("controls"))
+        )
+        != default_controls()
+    ):
+        raise TradeCumulusVariationError(
+            "Extended characterization package no longer matches its authorized reference."
+        )
+    return _authorized_extended_profile()
+
+
+def _require_unused_characterization_authorization(
+    settings: CloudChamberSettings,
+    authorization_id: str,
+) -> None:
+    runs_dir = settings.runtime_home.expanduser() / "runs"
+    if not runs_dir.exists():
+        return
+    for manifest_path in runs_dir.glob("*/run_manifest.json"):
+        try:
+            manifest = load_run_manifest(manifest_path)
+        except (OSError, ValueError):
+            continue
+        authorization = manifest.run_configuration.get("characterization_authorization")
+        if (
+            isinstance(authorization, dict)
+            and authorization.get("authorization_id") == authorization_id
+        ):
+            raise TradeCumulusVariationError(
+                "The one-package Extended characterization authorization has already been used."
+            )
 
 
 def _request_errors(

--- a/app/backend/cloud_chamber/world_compare.py
+++ b/app/backend/cloud_chamber/world_compare.py
@@ -191,19 +191,23 @@ def _trade_descriptor(
         left_simulation_id or default_left,
         right_simulation_id or default_right,
     )
-    differences = _trade_differences(left, right, world.simulations)
+    records = {item.simulation_id: item for item in world.simulations}
+    left_record = records[left.simulation_id]
+    right_record = records[right.simulation_id]
+    direct_relationship = _trade_envelope_relationship(left_record, right_record)
+    differences = _trade_differences(left_record, right_record)
+    pair_classification = direct_relationship or _trade_pair_classification(
+        left_record,
+        right_record,
+        differences,
+    )
+    controlled = pair_classification == "controlled_physical_variation"
     compatibility = _compatibility(
         left,
         right,
-        relationship=_relationship(left, right),
-        controlled_pair=bool(
-            {left.simulation_id, right.simulation_id} == {default_left, default_right}
-        ),
-        controlled_message=(
-            "Only surface moisture supply changed; the retained pair is a controlled comparison."
-            if {left.simulation_id, right.simulation_id} == {default_left, default_right}
-            else "The selected Trade Cumulus relationship is not the approved controlled pair."
-        ),
+        relationship=_trade_relationship_message(left, right, pair_classification),
+        controlled_pair=controlled,
+        controlled_message=_trade_controlled_message(pair_classification),
     )
     return WorldCompareDescriptor(
         world_id="trade_cumulus",
@@ -362,10 +366,34 @@ def _supercells_descriptor(
 def _trade_simulation(record: SimulationRecord) -> CompareSimulationDescriptor:
     if record.simulation_id is None:
         raise ValueError("Trade Cumulus Compare requires stable Simulation identity.")
+    configuration = record.configuration or {}
+    domain = configuration.get("domain") if isinstance(configuration, Mapping) else {}
+    domain = domain if isinstance(domain, Mapping) else {}
+    observation = record.observation_plan if isinstance(record.observation_plan, Mapping) else {}
+    duration = _number(
+        observation.get("duration_seconds"),
+        _number(configuration.get("duration_seconds"), 14_400),
+    )
+    cadence = _number(
+        observation.get("output_cadence_seconds"),
+        _number(configuration.get("output_cadence_seconds"), 60),
+    )
+    nx = int(_number(domain.get("nx"), 96))
+    ny = int(_number(domain.get("ny"), 96))
+    nz = int(_number(domain.get("nz"), 100))
+    dx = _number(domain.get("dx_m"), 66.6666667)
+    dy = _number(domain.get("dy_m"), 66.6666667)
+    dz = _number(domain.get("dz_m"), 30)
+    model_top = _number(domain.get("model_top_m"), nz * dz)
     is_more_moisture = record.simulation_id == "trade_cumulus_more_moisture"
-    time_seconds = 13_920.0 if is_more_moisture else 12_060.0
-    plane_index = 72 if is_more_moisture else 83
-    plane_coordinate = 1.6333333253860474 if is_more_moisture else 2.366666555404663
+    is_baseline = record.simulation_id == "trade_cumulus_canonical_bomex"
+    time_seconds = 13_920.0 if is_more_moisture else (12_060.0 if is_baseline else duration)
+    time_seconds = min(time_seconds, duration)
+    plane_index = 72 if is_more_moisture else (83 if is_baseline else ny // 2)
+    plane_index = min(max(plane_index, 0), max(ny - 1, 0))
+    plane_coordinate = (
+        1.6333333253860474 if is_more_moisture else (2.366666555404663 if is_baseline else 0.0)
+    )
     return CompareSimulationDescriptor(
         simulation_id=record.simulation_id,
         display_name=record.display_name,
@@ -382,17 +410,17 @@ def _trade_simulation(record: SimulationRecord) -> CompareSimulationDescriptor:
         inspectable=record.explore_available,
         grid=CompareGridDescriptor(
             topology="native_3d",
-            nx=96,
-            ny=96,
-            nz=100,
-            dx_m=66.6666667,
-            dy_m=66.6666667,
-            dz_m=30.0,
-            x_extent_km=(-3.2, 3.2),
-            y_extent_km=(-3.2, 3.2),
-            z_extent_km=(0.0, 3.0),
+            nx=nx,
+            ny=ny,
+            nz=nz,
+            dx_m=dx,
+            dy_m=dy,
+            dz_m=dz,
+            x_extent_km=(-0.5 * nx * dx / 1_000, 0.5 * nx * dx / 1_000),
+            y_extent_km=(-0.5 * ny * dy / 1_000, 0.5 * ny * dy / 1_000),
+            z_extent_km=(0.0, model_top / 1_000),
         ),
-        time=_regular_time_descriptor(14_400, 60),
+        time=_regular_time_descriptor(duration, cadence),
         available_field_ids=["ql", "w"],
         available_view_ids=["field", "updraft_lens"],
         fixed_scale_ids=["trade_cumulus_updraft_velocity_v1"],
@@ -708,27 +736,17 @@ def _relationship(
 
 
 def _trade_differences(
-    left: CompareSimulationDescriptor,
-    right: CompareSimulationDescriptor,
-    records: list[SimulationRecord],
+    left: SimulationRecord,
+    right: SimulationRecord,
 ) -> list[CompareDifference]:
-    if right.simulation_id == "trade_cumulus_more_moisture":
-        source = next(
-            item for item in records if item.simulation_id == "trade_cumulus_more_moisture"
-        )
-        reverse = False
-    elif left.simulation_id == "trade_cumulus_more_moisture":
-        source = next(
-            item for item in records if item.simulation_id == "trade_cumulus_more_moisture"
-        )
-        reverse = True
-    else:
-        return []
-    differences = []
-    for item in source.configuration_difference_from_reference or []:
-        if not item.material:
-            continue
-        differences.append(
+    child = (
+        right
+        if right.parent_simulation_id == left.simulation_id
+        else (left if left.parent_simulation_id == right.simulation_id else None)
+    )
+    if child is not None and child.configuration_difference_from_reference is not None:
+        reverse = child is left
+        return [
             CompareDifference(
                 path=item.path,
                 label=item.label,
@@ -738,8 +756,175 @@ def _trade_differences(
                 units=item.units,
                 material=True,
             )
+            for item in child.configuration_difference_from_reference
+            if item.material
+        ]
+
+    rows: list[CompareDifference] = []
+    for prefix, category, left_payload, right_payload in (
+        (
+            "scientific_design",
+            "atmospheric",
+            left.scientific_design,
+            right.scientific_design,
+        ),
+        (
+            "numerical_realization",
+            "numerical",
+            left.numerical_realization,
+            right.numerical_realization,
+        ),
+        (
+            "observation_plan",
+            "output",
+            left.observation_plan,
+            right.observation_plan,
+        ),
+    ):
+        for item in _mapping_differences(left_payload, right_payload):
+            rows.append(
+                item.model_copy(
+                    update={
+                        "path": f"{prefix}.{item.path}",
+                        "label": _trade_difference_label(f"{prefix}.{item.path}"),
+                        "category": category,
+                        "units": _trade_difference_units(f"{prefix}.{item.path}"),
+                    }
+                )
+            )
+    return rows
+
+
+def _trade_envelope_relationship(
+    left: SimulationRecord,
+    right: SimulationRecord,
+) -> str | None:
+    if right.parent_simulation_id == left.simulation_id:
+        return right.relationship_classification
+    if left.parent_simulation_id == right.simulation_id:
+        return left.relationship_classification
+    return None
+
+
+def _trade_pair_classification(
+    left: SimulationRecord,
+    right: SimulationRecord,
+    differences: list[CompareDifference],
+) -> str:
+    if (
+        left.source_recipe_id
+        and right.source_recipe_id
+        and left.source_recipe_id != right.source_recipe_id
+    ):
+        return "different_recipes"
+    physical = [item for item in differences if item.category == "atmospheric"]
+    numerical = [item for item in differences if item.category == "numerical"]
+    observation = [item for item in differences if item.category == "output"]
+    if physical and (numerical or observation):
+        return "mixed_variation"
+    if numerical:
+        return "numerical_sensitivity"
+    if physical:
+        return (
+            "controlled_physical_variation"
+            if len(physical) == 1
+            else "multi_factor_physical_variation"
         )
-    return differences
+    if observation:
+        return "observation_only_attempt"
+    return "replicate_realization"
+
+
+def _trade_relationship_message(
+    left: CompareSimulationDescriptor,
+    right: CompareSimulationDescriptor,
+    classification: str,
+) -> str:
+    relationship = classification.replace("_", " ")
+    if right.parent_simulation_id == left.simulation_id:
+        return f"{right.display_name} is a {relationship} of {left.display_name}."
+    if left.parent_simulation_id == right.simulation_id:
+        return f"{left.display_name} is a {relationship} of {right.display_name}."
+    if classification == "different_recipes":
+        return "The selected Simulations do not share one Trade Cumulus Recipe."
+    return f"The selected same-Recipe Simulations form a {relationship}."
+
+
+def _trade_controlled_message(classification: str) -> str:
+    messages = {
+        "controlled_physical_variation": (
+            "One material physical control changed while the numerical and observation "
+            "layers remain matched."
+        ),
+        "multi_factor_physical_variation": (
+            "Multiple physical controls changed; this is not a one-factor comparison."
+        ),
+        "numerical_sensitivity": (
+            "The numerical realization changed without a material physical-control change."
+        ),
+        "mixed_variation": (
+            "Physical controls and the numerical or observation layer both changed."
+        ),
+        "observation_only_attempt": (
+            "Only the observation plan changed; the physical design remains matched."
+        ),
+        "replicate_realization": "No material normalized difference is recorded.",
+        "different_recipes": "The selected Simulations do not share one Recipe contract.",
+    }
+    return messages.get(classification, f"Pair classification: {classification}.")
+
+
+def _trade_difference_label(path: str) -> str:
+    labels = {
+        "scientific_design.controls.surface_sensible_heat_flux_k_m_s": (
+            "Surface sensible heat flux"
+        ),
+        "scientific_design.controls.surface_moisture_flux_g_kg_m_s": ("Surface moisture flux"),
+        "scientific_design.controls.sub_inversion_total_water_g_kg": (
+            "Sub-inversion total-water mean"
+        ),
+        "scientific_design.controls.inversion_base_m_agl": "Inversion base",
+        "scientific_design.controls.inversion_thickness_m": "Inversion thickness",
+        "scientific_design.controls.inversion_strength_k": "Inversion strength",
+        "scientific_design.controls.free_tropospheric_rh_percent": ("Free-tropospheric mean RH"),
+        "scientific_design.controls.cloud_layer_shear_m_s": "0–3 km shear",
+        "scientific_design.controls.cloud_layer_shear_direction_deg": ("0–3 km shear direction"),
+        "scientific_design.controls.cloud_layer_mean_u_m_s": "0–3 km mean u wind",
+        "scientific_design.controls.cloud_layer_mean_v_m_s": "0–3 km mean v wind",
+        "scientific_design.controls.large_scale_vertical_motion_m_s": (
+            "Peak large-scale vertical motion"
+        ),
+        "scientific_design.controls.temperature_tendency_k_day": ("Peak temperature tendency"),
+        "scientific_design.controls.total_water_tendency_g_kg_day": ("Peak total-water tendency"),
+        "observation_plan.output_cadence_seconds": "Saved-output cadence",
+        "observation_plan.duration_seconds": "Simulation duration",
+        "observation_plan.expected_history_count": "Expected saved outputs",
+    }
+    return labels.get(path, path.replace(".", " / ").replace("_", " ").title())
+
+
+def _trade_difference_units(path: str) -> str | None:
+    if path.endswith("surface_sensible_heat_flux_k_m_s"):
+        return "K m/s"
+    if path.endswith("surface_moisture_flux_g_kg_m_s"):
+        return "g/kg m/s"
+    if path.endswith(("sub_inversion_total_water_g_kg", "total_water_tendency_g_kg_day")):
+        return "g/kg" if path.endswith("_g_kg") else "g/kg/day"
+    if path.endswith(("_base_m_agl", "_thickness_m")):
+        return "m"
+    if path.endswith("_strength_k"):
+        return "K"
+    if path.endswith("_rh_percent"):
+        return "%"
+    if path.endswith(("_shear_m_s", "_mean_u_m_s", "_mean_v_m_s", "_motion_m_s")):
+        return "m/s"
+    if path.endswith("_direction_deg"):
+        return "deg"
+    if path.endswith("_tendency_k_day"):
+        return "K/day"
+    if path.endswith("_seconds"):
+        return "s"
+    return None
 
 
 def _mapping_differences(

--- a/app/backend/tests/test_app.py
+++ b/app/backend/tests/test_app.py
@@ -44,9 +44,39 @@ from cloud_chamber.trade_cumulus_comparison_story import (
     TradeCumulusComparisonStoryConflict,
     TradeCumulusComparisonStoryNotFound,
 )
+from cloud_chamber.trade_cumulus_recipes import (
+    TradeCumulusControls,
+)
+from cloud_chamber.trade_cumulus_variations import TradeCumulusVariationError
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 BASELINE_TEMPLATE = REPO_ROOT / "scenarios/lower-atmosphere/baseline-shallow-cumulus.json"
+
+
+def test_trade_cumulus_package_reports_preflight_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "cloud_chamber.app.create_trade_cumulus_variation",
+        lambda _settings, _request: (_ for _ in ()).throw(
+            TradeCumulusVariationError("Variation package preflight failed.")
+        ),
+    )
+    monkeypatch.setattr("cloud_chamber.app.load_settings", lambda: SimpleNamespace())
+
+    response = TestClient(app).post(
+        "/api/worlds/trade-cumulus/variations",
+        json={
+            "parent_simulation_id": "trade_cumulus_canonical_bomex",
+            "simulation_name": "Direct-value experiment",
+            "user_question": "How does the requested forcing change the cloud field?",
+            "run_profile_id": "trade_cumulus_standard_v1",
+            "controls": TradeCumulusControls().model_dump(mode="json"),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Variation package preflight failed."}
 
 
 def test_mountain_waves_package_reports_clean_worktree_guard(

--- a/app/backend/tests/test_local_run_manager.py
+++ b/app/backend/tests/test_local_run_manager.py
@@ -18,6 +18,7 @@ from cloud_chamber.local_run_manager import (
     LocalRunManagerError,
     default_process_factory,
 )
+from cloud_chamber.run_cost import LaunchBudgetError
 from cloud_chamber.run_manifest import (
     LifecycleState,
     ProductState,
@@ -456,6 +457,55 @@ def test_launch_applies_differential_surface_source_customization_before_cm1(
     assert launched_manifest.cm1_source_customization_status == status_payload
     assert SFCPHYS_MARKER not in (cm1_root / "src" / "sfcphys.F").read_text()
     assert custom_executable.exists()
+
+
+def test_launch_rechecks_disk_after_source_build_and_before_process_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = fake_settings(tmp_path)
+    assert settings.cm1_root is not None
+    write_fake_cm1_source_tree(settings)
+    manifest_path = differential_dry_run_manifest_path(tmp_path)
+    run_dir = tmp_path / "CloudChamber" / "runs" / "run-diff"
+    factory = FakeProcessFactory(FakeProcess())
+    build_completed = False
+
+    def fake_build(
+        command: list[str],
+        *,
+        cwd: Path,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal build_completed
+        build_completed = True
+        return subprocess.CompletedProcess(command, 0, stdout="built\n", stderr="")
+
+    def blocked_final_gate(*_args: Any, **_kwargs: Any) -> None:
+        assert build_completed is True
+        assert (run_dir / CUSTOM_EXECUTABLE_FILENAME).is_file()
+        raise LaunchBudgetError("post-build reserve no longer fits")
+
+    monkeypatch.setattr(
+        "cloud_chamber.local_run_manager.preflight_manifest_launch_budget",
+        blocked_final_gate,
+    )
+    manager = LocalRunManager(
+        settings=settings,
+        process_factory=factory,
+        source_build_runner=fake_build,
+    )
+
+    with pytest.raises(
+        LocalRunManagerError,
+        match="Final disk gate failed after source staging.*post-build reserve",
+    ):
+        manager.launch(manifest_path)
+
+    assert factory.commands == []
+    assert load_run_manifest(manifest_path).lifecycle_state == LifecycleState.PACKAGED
 
 
 def test_launch_applies_straight_line_hodograph_source_customization_before_cm1(

--- a/app/backend/tests/test_local_run_manager.py
+++ b/app/backend/tests/test_local_run_manager.py
@@ -283,6 +283,10 @@ def test_launch_constructs_cm1_command_and_captures_logs(tmp_path: Path) -> None
     assert manifest.lifecycle_state == LifecycleState.RUNNING
     assert manifest.provenance.product_state == ProductState.QUEUED_RUNNING_CM1_PROCESS
     assert manifest.execution.command == [str(settings.cm1_run_dir / "cm1.exe")]
+    assert (
+        manifest.execution.executable_sha256
+        == hashlib.sha256((settings.cm1_run_dir / "cm1.exe").read_bytes()).hexdigest()
+    )
     assert manifest.execution.process_id == fake_process.pid
 
 

--- a/app/backend/tests/test_trade_cumulus_forcing.py
+++ b/app/backend/tests/test_trade_cumulus_forcing.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from cloud_chamber.trade_cumulus_forcing import (
+    TRADE_CUMULUS_FORCING_MARKER,
+    TradeCumulusForcingError,
+    forcing_customization_artifact,
+    render_trade_cumulus_forcing_source,
+    verify_forcing_artifact,
+)
+
+
+def _source() -> str:
+    return """\
+    IF( testcase .eq. 3 )THEN
+      ! shallow Cu case  (Siebesma et al, 2003, JAS)
+      wmin  =  -0.0065
+      radsfc = -2.0/( 3600.0 * 24.0 )
+      qvsfc  = -1.2e-8
+      qvfrc(k) = -1.2e-8
+    ENDIF
+    IF( testcase .eq. 4 )THEN
+    ENDIF
+"""
+
+
+def test_forcing_artifact_is_source_locked_and_uses_absolute_values(tmp_path: Path) -> None:
+    artifact = forcing_customization_artifact(
+        _source(),
+        vertical_motion_m_s=0.015,
+        temperature_tendency_k_day=4.0,
+        total_water_tendency_g_kg_day=6.0,
+    )
+    path = tmp_path / "trade_cumulus_forcing_customization.json"
+    import json
+
+    path.write_text(json.dumps(artifact))
+    verified = verify_forcing_artifact(path, _source())
+    rendered = render_trade_cumulus_forcing_source(_source(), verified["forcing"])
+
+    assert TRADE_CUMULUS_FORCING_MARKER in rendered
+    assert "wmin  =  1.500000000000d-02" in rendered
+    assert "radsfc = 4.629629629630d-05" in rendered
+    assert "qvsfc  = 6.944444444444d-08" in rendered
+    assert "qvfrc(k) = qvsfc" in rendered
+    assert artifact["original_source_sha256"] == hashlib.sha256(_source().encode()).hexdigest()
+
+
+def test_forcing_artifact_rejects_changed_or_already_patched_source(tmp_path: Path) -> None:
+    artifact = forcing_customization_artifact(
+        _source(),
+        vertical_motion_m_s=-0.01,
+        temperature_tendency_k_day=-3.0,
+        total_water_tendency_g_kg_day=-2.0,
+    )
+    path = tmp_path / "forcing.json"
+    import json
+
+    path.write_text(json.dumps(artifact))
+
+    with pytest.raises(TradeCumulusForcingError, match="does not match"):
+        verify_forcing_artifact(path, _source() + "! changed\n")
+    with pytest.raises(TradeCumulusForcingError, match="already contains"):
+        render_trade_cumulus_forcing_source(
+            _source().replace(
+                "! shallow Cu case  (Siebesma et al, 2003, JAS)",
+                f"! {TRADE_CUMULUS_FORCING_MARKER}",
+            ),
+            artifact["forcing"],
+        )

--- a/app/backend/tests/test_trade_cumulus_output_validation.py
+++ b/app/backend/tests/test_trade_cumulus_output_validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -9,6 +10,14 @@ import numpy as np
 import pytest
 import xarray as xr
 
+from cloud_chamber.bomex_case import (
+    CM1_EXECUTABLE_SHA256,
+    CM1_SOURCE_MANIFEST_SHA256,
+    CRITICAL_SOURCE_HASHES,
+)
+from cloud_chamber.cm1_source_customization import (
+    CUSTOM_EXECUTABLE_FILENAME,
+)
 from cloud_chamber.result_ingest import ResultMetadata
 from cloud_chamber.run_manifest import (
     AppMetadata,
@@ -23,6 +32,11 @@ from cloud_chamber.run_manifest import (
     ScenarioReference,
     UserMetadata,
     ValidationStatus,
+)
+from cloud_chamber.trade_cumulus_forcing import (
+    TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND,
+    TRADE_CUMULUS_FORCING_SCHEMA_VERSION,
+    TRADE_CUMULUS_FORCING_TARGET,
 )
 from cloud_chamber.trade_cumulus_output_validation import (
     TradeCumulusOutputValidationError,
@@ -77,7 +91,16 @@ def test_valid_output_is_cached_and_cloud_free_response_is_available(
         ("missing_w", "Required native field w is absent"),
         ("wrong_ql_units", "unsupported units"),
         ("nonfinite_w", "contains nonfinite values"),
-        ("wrong_time", "reviewed output cadence"),
+        ("wrong_grid", "reviewed grid"),
+        ("wrong_spacing", "reviewed spacing"),
+        ("wrong_extent", "reviewed domain bounds"),
+        ("wrong_top", "reviewed model top"),
+        ("wrong_start", "exact reviewed timeline"),
+        ("wrong_time", "exact reviewed timeline"),
+        ("wrong_end", "exact reviewed timeline"),
+        ("escaped_output", "escapes the accepted attempt directory"),
+        ("wrong_surface_flux", "does not match the reviewed target"),
+        ("wrong_provenance", "approved source manifest"),
     ],
 )
 def test_invalid_native_output_fails_closed(
@@ -99,10 +122,58 @@ def test_generated_input_tampering_fails_before_output_promotion(tmp_path: Path)
         validate_trade_cumulus_variation_outputs(manifest, metadata)
 
 
+def test_forcing_modified_output_binds_package_build_executable_and_readback(
+    tmp_path: Path,
+) -> None:
+    manifest, metadata = _artifacts(tmp_path, forcing_customization=True)
+
+    report = validate_trade_cumulus_variation_outputs(manifest, metadata)
+
+    provenance = report["attempt_provenance"]
+    assert provenance["customization_kind"] == TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND
+    assert provenance["executable_kind"] == "isolated_forcing_customization"
+    assert provenance["forcing_readback"] == {
+        "vertical_motion_m_s": 0.01,
+        "temperature_tendency_k_day": 3.0,
+        "total_water_tendency_g_kg_day": -4.0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("corruption", "message"),
+    [
+        ("wrong_applied_forcing", "does not match the reviewed forcing targets"),
+        ("wrong_execution_command", "did not use the applied custom executable"),
+        ("tampered_custom_executable", "hash does not match"),
+    ],
+)
+def test_forcing_modified_output_fails_closed_on_unbound_execution(
+    tmp_path: Path,
+    corruption: str,
+    message: str,
+) -> None:
+    manifest, metadata = _artifacts(tmp_path, forcing_customization=True)
+    status = dict(manifest.cm1_source_customization_status or {})
+    if corruption == "wrong_applied_forcing":
+        status["forcing"] = {
+            **dict(status["forcing"]),
+            "temperature_tendency_k_day": 2.0,
+        }
+        manifest.cm1_source_customization_status = status
+    elif corruption == "wrong_execution_command":
+        manifest.execution.command = ["/approved/canonical/cm1.exe"]
+    else:
+        Path(str(status["custom_executable"])).write_bytes(b"tampered executable")
+
+    with pytest.raises(TradeCumulusOutputValidationError, match=message):
+        validate_trade_cumulus_variation_outputs(manifest, metadata)
+
+
 def _artifacts(
     tmp_path: Path,
     *,
     corruption: str | None = None,
+    forcing_customization: bool = False,
 ) -> tuple[RunManifest, ResultMetadata]:
     run_dir = tmp_path / "runs" / "trade-output-validation"
     run_dir.mkdir(parents=True)
@@ -112,28 +183,122 @@ def _artifacts(
     namelist.write_text("isnd = 7,\n")
     sounding.write_text("1015.0 298.7 17.0\n0.0 298.7 17.0 -8.75 0.0\n")
     checklist.write_text("{}\n")
+    controls = default_controls()
+    customization_path: Path | None = None
+    customization_status: dict[str, Any] | None = None
+    execution_command: list[str] = []
+    if forcing_customization:
+        controls = controls.model_copy(
+            update={
+                "large_scale_vertical_motion_m_s": 0.01,
+                "temperature_tendency_k_day": 3.0,
+                "total_water_tendency_g_kg_day": -4.0,
+            }
+        )
+        forcing = {
+            "vertical_motion_m_s": 0.01,
+            "temperature_tendency_k_day": 3.0,
+            "total_water_tendency_g_kg_day": -4.0,
+        }
+        customization_path = run_dir / "trade_cumulus_forcing_customization.json"
+        customization_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": TRADE_CUMULUS_FORCING_SCHEMA_VERSION,
+                    "customization_kind": TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND,
+                    "target": str(TRADE_CUMULUS_FORCING_TARGET),
+                    "original_source_sha256": CRITICAL_SOURCE_HASHES[
+                        str(TRADE_CUMULUS_FORCING_TARGET)
+                    ],
+                    "patched_source_sha256": "d" * 64,
+                    "forcing": forcing,
+                }
+            )
+        )
+        build_root = tmp_path / "cm1_source_builds" / "fixture-build"
+        build_root.mkdir(parents=True)
+        executable = run_dir / CUSTOM_EXECUTABLE_FILENAME
+        executable.write_bytes(b"custom executable")
+        executable_sha256 = hashlib.sha256(executable.read_bytes()).hexdigest()
+        execution_command = [str(executable)]
+        customization_status = {
+            "schema_version": "cm1_source_customization_status_v1",
+            "customization_kind": TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND,
+            "run_id": "trade-output-validation",
+            "customization_manifest": str(customization_path),
+            "original_target_sha256": CRITICAL_SOURCE_HASHES[str(TRADE_CUMULUS_FORCING_TARGET)],
+            "patched_target_sha256": "d" * 64,
+            "patched_files": [str(TRADE_CUMULUS_FORCING_TARGET)],
+            "source_restored_after_build": "not_modified_isolated_build_tree",
+            "build_command": ["make"],
+            "build_root": str(build_root),
+            "custom_executable": str(executable),
+            "custom_executable_sha256": executable_sha256,
+            "forcing": forcing,
+            "no_silent_forcing_fallback": True,
+        }
+    generated_paths = [namelist, sounding, checklist]
+    if customization_path is not None:
+        generated_paths.append(customization_path)
     generated_hashes = {
-        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
-        for path in (namelist, sounding, checklist)
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in generated_paths
     }
 
     paths: list[Path] = []
-    for index, time_seconds in enumerate((0.0, 60.0, 120.0), start=1):
-        path = run_dir / f"cm1out_{index:06d}.nc"
+    times = [0.0, 60.0, 120.0]
+    if corruption == "wrong_start":
+        times[0] = 1.0
+    elif corruption == "wrong_time":
+        times[1] = 61.0
+    elif corruption == "wrong_end":
+        times[2] = 121.0
+    for index, time_seconds in enumerate(times, start=1):
+        path = (
+            tmp_path / f"escaped_cm1out_{index:06d}.nc"
+            if corruption == "escaped_output" and index == 2
+            else run_dir / f"cm1out_{index:06d}.nc"
+        )
         _write_history(
             path,
-            time_seconds=(90.0 if corruption == "wrong_time" and index == 2 else time_seconds),
+            time_seconds=time_seconds,
             missing_w=corruption == "missing_w" and index == 2,
             wrong_ql_units=corruption == "wrong_ql_units" and index == 2,
             nonfinite_w=corruption == "nonfinite_w" and index == 2,
+            wrong_grid=corruption == "wrong_grid" and index == 2,
+            wrong_spacing=corruption == "wrong_spacing" and index == 2,
+            wrong_extent=corruption == "wrong_extent" and index == 2,
+            wrong_top=corruption == "wrong_top" and index == 2,
+            wrong_surface_flux=corruption == "wrong_surface_flux" and index == 2,
         )
         paths.append(path)
 
     scientific = {
-        "controls": default_controls().model_dump(mode="json"),
+        "controls": controls.model_dump(mode="json"),
         "fixed_assumptions": {"physics": "nonprecipitating"},
     }
-    numerical = {"grid": "fixture"}
+    numerical = {
+        "domain": "200 m × 200 m × 200 m",
+        "grid": "2 × 2 × 2",
+        "spacing": "100 × 100 × 100 m",
+        "timestep_strategy": "target 1 s",
+        "physics_source": "test fixture",
+        "exact_domain": {
+            "nx": 2,
+            "ny": 2,
+            "nz": 2,
+            "dx_m": 100.0,
+            "dy_m": 100.0,
+            "dz_m": 100.0,
+            "x_extent_m": 200.0,
+            "y_extent_m": 200.0,
+            "model_top_m": 200.0,
+            "x_min_m": -100.0,
+            "x_max_m": 100.0,
+            "y_min_m": -100.0,
+            "y_max_m": 100.0,
+            "timestep_seconds": 1.0,
+        },
+    }
     identity = canonical_payload_sha256(
         {"scientific_design": scientific, "numerical_realization": numerical}
     )
@@ -158,6 +323,7 @@ def _artifacts(
                     "qv",
                     "th",
                     "prs",
+                    "rho",
                     "u",
                     "v",
                     "w",
@@ -171,7 +337,7 @@ def _artifacts(
                 ],
             }
         ),
-        world_payload={"controls": default_controls().model_dump(mode="json")},
+        world_payload={"controls": controls.model_dump(mode="json")},
         differences=[],
         relationship_classification="replicate_realization",
         run_profile_id="fixture",
@@ -202,9 +368,14 @@ def _artifacts(
             "variation_envelope": envelope.model_dump(mode="json"),
             "generated_input_sha256": generated_hashes,
             "cm1_provenance": {
-                "source_manifest_sha256": "a" * 64,
-                "executable_sha256": "b" * 64,
+                "source_manifest_sha256": (
+                    "0" * 64 if corruption == "wrong_provenance" else CM1_SOURCE_MANIFEST_SHA256
+                ),
+                "executable_sha256": CM1_EXECUTABLE_SHA256,
             },
+            "cm1_source_customization_kind": (
+                TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND if forcing_customization else None
+            ),
         },
         physical_question="Can retained output support Explore?",
         expected_diagnostics=[],
@@ -213,6 +384,9 @@ def _artifacts(
             manifest_path=str(manifest_path),
             namelist_input=str(namelist),
             input_sounding=str(sounding),
+            cm1_source_customization=(
+                str(customization_path) if customization_path is not None else None
+            ),
             runtime_file_checklist=[str(checklist)],
         ),
         runtime_paths=RuntimePaths(runtime_home=str(tmp_path)),
@@ -220,13 +394,19 @@ def _artifacts(
         lifecycle_state=LifecycleState.COMPLETED,
         validation_status=ValidationStatus.NEEDS_REVIEW,
         provenance=ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
-        execution=ExecutionMetadata(started_at=now, finished_at=now, exit_code=0),
+        execution=ExecutionMetadata(
+            command=execution_command,
+            started_at=now,
+            finished_at=now,
+            exit_code=0,
+        ),
         outputs=OutputMetadata(netcdf_paths=[str(path) for path in paths]),
         required_output_fields=[
             "ql",
             "qv",
             "th",
             "prs",
+            "rho",
             "u",
             "v",
             "w",
@@ -241,6 +421,7 @@ def _artifacts(
         created_at=now,
         updated_at=now,
         user=UserMetadata(name="Output validation fixture"),
+        cm1_source_customization_status=customization_status,
     )
     metadata = ResultMetadata(
         result_id="result-trade-output-validation",
@@ -272,8 +453,14 @@ def _write_history(
     missing_w: bool,
     wrong_ql_units: bool,
     nonfinite_w: bool,
+    wrong_grid: bool,
+    wrong_spacing: bool,
+    wrong_extent: bool,
+    wrong_top: bool,
+    wrong_surface_flux: bool,
 ) -> None:
-    shape = (1, 2, 2, 2)
+    x_count = 3 if wrong_grid else 2
+    shape = (1, 2, 2, x_count)
     scalar = np.ones(shape, dtype=np.float32)
     cloud = np.zeros(shape, dtype=np.float32)
     vertical = scalar.copy()
@@ -284,15 +471,26 @@ def _write_history(
         "qv": (("time", "zh", "yh", "xh"), scalar * 0.01),
         "th": (("time", "zh", "yh", "xh"), scalar * 300),
         "prs": (("time", "zh", "yh", "xh"), scalar * 90_000),
+        "rho": (("time", "zh", "yh", "xh"), scalar * 1.2),
         "u": (("time", "zh", "yh", "xh"), scalar * -7),
         "v": (("time", "zh", "yh", "xh"), scalar * 1),
         "tke": (("time", "zh", "yh", "xh"), scalar),
         "kmh": (("time", "zh", "yh", "xh"), scalar),
         "khh": (("time", "zh", "yh", "xh"), scalar),
-        "cwp": (("time", "yh", "xh"), np.ones((1, 2, 2), dtype=np.float32)),
-        "hfx": (("time", "yh", "xh"), np.ones((1, 2, 2), dtype=np.float32)),
-        "qfx": (("time", "yh", "xh"), np.ones((1, 2, 2), dtype=np.float32)),
-        "rain": (("time", "yh", "xh"), np.zeros((1, 2, 2), dtype=np.float32)),
+        "cwp": (("time", "yh", "xh"), np.ones((1, 2, x_count), dtype=np.float32)),
+        "hfx": (
+            ("time", "yh", "xh"),
+            np.full(
+                (1, 2, x_count),
+                1.2 * 1_004.0 * (0.009 if wrong_surface_flux else 0.008),
+                dtype=np.float32,
+            ),
+        ),
+        "qfx": (
+            ("time", "yh", "xh"),
+            np.full((1, 2, x_count), 1.2 * 0.052 / 1_000.0, dtype=np.float32),
+        ),
+        "rain": (("time", "yh", "xh"), np.zeros((1, 2, x_count), dtype=np.float32)),
     }
     if not missing_w:
         data_vars["w"] = (("time", "zh", "yh", "xh"), vertical)
@@ -300,9 +498,25 @@ def _write_history(
         data_vars,
         coords={
             "time": ("time", [time_seconds], {"units": "seconds"}),
-            "zh": ("zh", [0.1, 0.2], {"units": "km"}),
-            "yh": ("yh", [-0.1, 0.1], {"units": "km"}),
-            "xh": ("xh", [-0.1, 0.1], {"units": "km"}),
+            "zh": (
+                "zh",
+                [0.1, 0.2] if wrong_top else [0.05, 0.15],
+                {"units": "km"},
+            ),
+            "yh": ("yh", [-0.05, 0.05], {"units": "km"}),
+            "xh": (
+                "xh",
+                (
+                    [-0.1, 0.0, 0.1]
+                    if wrong_grid
+                    else [-0.06, 0.06]
+                    if wrong_spacing
+                    else [0.05, 0.15]
+                    if wrong_extent
+                    else [-0.05, 0.05]
+                ),
+                {"units": "km"},
+            ),
         },
     )
     for field in ("ql", "qv"):
@@ -310,6 +524,9 @@ def _write_history(
     dataset["ql"].attrs["units"] = "g kg-1" if wrong_ql_units else "kg kg-1"
     dataset["th"].attrs["units"] = "K"
     dataset["prs"].attrs["units"] = "Pa"
+    dataset["rho"].attrs["units"] = "kg m-3"
+    dataset["hfx"].attrs["units"] = "W m-2"
+    dataset["qfx"].attrs["units"] = "kg m-2 s-1"
     for field in ("u", "v"):
         dataset[field].attrs["units"] = "m s-1"
     if "w" in dataset:

--- a/app/backend/tests/test_trade_cumulus_output_validation.py
+++ b/app/backend/tests/test_trade_cumulus_output_validation.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from cloud_chamber.result_ingest import ResultMetadata
+from cloud_chamber.run_manifest import (
+    AppMetadata,
+    ExecutionMetadata,
+    GeneratedInputs,
+    LifecycleState,
+    OutputMetadata,
+    ProductState,
+    ProvenanceMetadata,
+    RunManifest,
+    RuntimePaths,
+    ScenarioReference,
+    UserMetadata,
+    ValidationStatus,
+)
+from cloud_chamber.trade_cumulus_output_validation import (
+    TradeCumulusOutputValidationError,
+    clear_trade_cumulus_output_validation_cache,
+    validate_trade_cumulus_variation_outputs,
+)
+from cloud_chamber.trade_cumulus_recipes import default_controls
+from cloud_chamber.variation_envelope import (
+    VariationAttempt,
+    VariationEnvelope,
+    canonical_payload_sha256,
+    immutable_layer,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> None:
+    clear_trade_cumulus_output_validation_cache()
+
+
+def test_valid_output_is_cached_and_cloud_free_response_is_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest, metadata = _artifacts(tmp_path)
+    original = xr.open_dataset
+    calls = 0
+
+    def counted(*args: Any, **kwargs: Any) -> xr.Dataset:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "cloud_chamber.trade_cumulus_output_validation.xr.open_dataset",
+        counted,
+    )
+
+    first = validate_trade_cumulus_variation_outputs(manifest, metadata)
+    second = validate_trade_cumulus_variation_outputs(manifest, metadata)
+
+    assert first == second
+    assert first["history_count"] == 3
+    assert first["cloud_response_required"] is False
+    assert first["resolved_fields"]["w"] == "w"
+    assert calls == 3
+
+
+@pytest.mark.parametrize(
+    ("corruption", "message"),
+    [
+        ("missing_w", "Required native field w is absent"),
+        ("wrong_ql_units", "unsupported units"),
+        ("nonfinite_w", "contains nonfinite values"),
+        ("wrong_time", "reviewed output cadence"),
+    ],
+)
+def test_invalid_native_output_fails_closed(
+    tmp_path: Path,
+    corruption: str,
+    message: str,
+) -> None:
+    manifest, metadata = _artifacts(tmp_path, corruption=corruption)
+
+    with pytest.raises(TradeCumulusOutputValidationError, match=message):
+        validate_trade_cumulus_variation_outputs(manifest, metadata)
+
+
+def test_generated_input_tampering_fails_before_output_promotion(tmp_path: Path) -> None:
+    manifest, metadata = _artifacts(tmp_path)
+    Path(manifest.generated_inputs.input_sounding or "").write_text("changed\n")
+
+    with pytest.raises(TradeCumulusOutputValidationError, match="changed after"):
+        validate_trade_cumulus_variation_outputs(manifest, metadata)
+
+
+def _artifacts(
+    tmp_path: Path,
+    *,
+    corruption: str | None = None,
+) -> tuple[RunManifest, ResultMetadata]:
+    run_dir = tmp_path / "runs" / "trade-output-validation"
+    run_dir.mkdir(parents=True)
+    namelist = run_dir / "namelist.input"
+    sounding = run_dir / "input_sounding"
+    checklist = run_dir / "runtime_file_checklist.json"
+    namelist.write_text("isnd = 7,\n")
+    sounding.write_text("1015.0 298.7 17.0\n0.0 298.7 17.0 -8.75 0.0\n")
+    checklist.write_text("{}\n")
+    generated_hashes = {
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in (namelist, sounding, checklist)
+    }
+
+    paths: list[Path] = []
+    for index, time_seconds in enumerate((0.0, 60.0, 120.0), start=1):
+        path = run_dir / f"cm1out_{index:06d}.nc"
+        _write_history(
+            path,
+            time_seconds=(90.0 if corruption == "wrong_time" and index == 2 else time_seconds),
+            missing_w=corruption == "missing_w" and index == 2,
+            wrong_ql_units=corruption == "wrong_ql_units" and index == 2,
+            nonfinite_w=corruption == "nonfinite_w" and index == 2,
+        )
+        paths.append(path)
+
+    scientific = {
+        "controls": default_controls().model_dump(mode="json"),
+        "fixed_assumptions": {"physics": "nonprecipitating"},
+    }
+    numerical = {"grid": "fixture"}
+    identity = canonical_payload_sha256(
+        {"scientific_design": scientific, "numerical_realization": numerical}
+    )
+    simulation_id = f"trade_cumulus_output_fixture_{identity[:8]}"
+    envelope = VariationEnvelope(
+        world_id="trade_cumulus",
+        recipe_id="canonical_bomex_trade_cumulus",
+        recipe_contract_version="1",
+        simulation_id=simulation_id,
+        parent_simulation_id="trade_cumulus_canonical_bomex",
+        reference_simulation_id="trade_cumulus_canonical_bomex",
+        display_name="Output validation fixture",
+        scientific_design=immutable_layer(scientific),
+        numerical_realization=immutable_layer(numerical),
+        observation_plan=immutable_layer(
+            {
+                "duration_seconds": 120,
+                "output_cadence_seconds": 60,
+                "expected_history_count": 3,
+                "retained_field_inventory": [
+                    "ql",
+                    "qv",
+                    "th",
+                    "prs",
+                    "u",
+                    "v",
+                    "w",
+                    "tke",
+                    "kmh",
+                    "khh",
+                    "cwp",
+                    "hfx",
+                    "qfx",
+                    "rain",
+                ],
+            }
+        ),
+        world_payload={"controls": default_controls().model_dump(mode="json")},
+        differences=[],
+        relationship_classification="replicate_realization",
+        run_profile_id="fixture",
+        run_profile_contract={},
+        cost_estimate={},
+        package_identity_sha256=identity,
+        attempts=[
+            VariationAttempt(
+                attempt_id="trade-output-validation",
+                run_id="trade-output-validation",
+                relationship="initial",
+                package_identity_sha256=identity,
+            )
+        ],
+    )
+    now = datetime(2026, 7, 28, tzinfo=UTC)
+    manifest_path = run_dir / "run_manifest.json"
+    manifest = RunManifest(
+        run_id="trade-output-validation",
+        scenario=ScenarioReference(
+            id="trade_cumulus_recipe_variation_v1",
+            schema_version="trade_cumulus_variation_v1",
+        ),
+        controls={},
+        run_configuration={
+            "cloud_world_id": "trade_cumulus",
+            "simulation_id": simulation_id,
+            "variation_envelope": envelope.model_dump(mode="json"),
+            "generated_input_sha256": generated_hashes,
+            "cm1_provenance": {
+                "source_manifest_sha256": "a" * 64,
+                "executable_sha256": "b" * 64,
+            },
+        },
+        physical_question="Can retained output support Explore?",
+        expected_diagnostics=[],
+        generated_inputs=GeneratedInputs(
+            run_directory=str(run_dir),
+            manifest_path=str(manifest_path),
+            namelist_input=str(namelist),
+            input_sounding=str(sounding),
+            runtime_file_checklist=[str(checklist)],
+        ),
+        runtime_paths=RuntimePaths(runtime_home=str(tmp_path)),
+        app=AppMetadata(app_version="test", commit="test"),
+        lifecycle_state=LifecycleState.COMPLETED,
+        validation_status=ValidationStatus.NEEDS_REVIEW,
+        provenance=ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+        execution=ExecutionMetadata(started_at=now, finished_at=now, exit_code=0),
+        outputs=OutputMetadata(netcdf_paths=[str(path) for path in paths]),
+        required_output_fields=[
+            "ql",
+            "qv",
+            "th",
+            "prs",
+            "u",
+            "v",
+            "w",
+            "tke",
+            "kmh",
+            "khh",
+            "cwp",
+            "hfx",
+            "qfx",
+            "rain",
+        ],
+        created_at=now,
+        updated_at=now,
+        user=UserMetadata(name="Output validation fixture"),
+    )
+    metadata = ResultMetadata(
+        result_id="result-trade-output-validation",
+        run_id=manifest.run_id,
+        scenario_id=manifest.scenario.id,
+        physical_question=manifest.physical_question,
+        controls={},
+        run_configuration=manifest.run_configuration,
+        source_lifecycle_state="completed",
+        source_product_state="completed_cm1_result",
+        source_model="CM1",
+        required_output_fields=manifest.required_output_fields,
+        model_output_paths=[str(path) for path in paths],
+        netcdf_paths=[str(path) for path in paths],
+        model_output_file_count=3,
+        time_steps=3,
+        first_output_time_seconds=0.0,
+        last_output_time_seconds=120.0,
+        created_at=now,
+        updated_at=now,
+    )
+    return manifest, metadata
+
+
+def _write_history(
+    path: Path,
+    *,
+    time_seconds: float,
+    missing_w: bool,
+    wrong_ql_units: bool,
+    nonfinite_w: bool,
+) -> None:
+    shape = (1, 2, 2, 2)
+    scalar = np.ones(shape, dtype=np.float32)
+    cloud = np.zeros(shape, dtype=np.float32)
+    vertical = scalar.copy()
+    if nonfinite_w:
+        vertical[0, 0, 0, 0] = np.nan
+    data_vars: dict[str, Any] = {
+        "ql": (("time", "zh", "yh", "xh"), cloud),
+        "qv": (("time", "zh", "yh", "xh"), scalar * 0.01),
+        "th": (("time", "zh", "yh", "xh"), scalar * 300),
+        "prs": (("time", "zh", "yh", "xh"), scalar * 90_000),
+        "u": (("time", "zh", "yh", "xh"), scalar * -7),
+        "v": (("time", "zh", "yh", "xh"), scalar * 1),
+        "tke": (("time", "zh", "yh", "xh"), scalar),
+        "kmh": (("time", "zh", "yh", "xh"), scalar),
+        "khh": (("time", "zh", "yh", "xh"), scalar),
+        "cwp": (("time", "yh", "xh"), np.ones((1, 2, 2), dtype=np.float32)),
+        "hfx": (("time", "yh", "xh"), np.ones((1, 2, 2), dtype=np.float32)),
+        "qfx": (("time", "yh", "xh"), np.ones((1, 2, 2), dtype=np.float32)),
+        "rain": (("time", "yh", "xh"), np.zeros((1, 2, 2), dtype=np.float32)),
+    }
+    if not missing_w:
+        data_vars["w"] = (("time", "zh", "yh", "xh"), vertical)
+    dataset = xr.Dataset(
+        data_vars,
+        coords={
+            "time": ("time", [time_seconds], {"units": "seconds"}),
+            "zh": ("zh", [0.1, 0.2], {"units": "km"}),
+            "yh": ("yh", [-0.1, 0.1], {"units": "km"}),
+            "xh": ("xh", [-0.1, 0.1], {"units": "km"}),
+        },
+    )
+    for field in ("ql", "qv"):
+        dataset[field].attrs["units"] = "kg kg-1"
+    dataset["ql"].attrs["units"] = "g kg-1" if wrong_ql_units else "kg kg-1"
+    dataset["th"].attrs["units"] = "K"
+    dataset["prs"].attrs["units"] = "Pa"
+    for field in ("u", "v"):
+        dataset[field].attrs["units"] = "m s-1"
+    if "w" in dataset:
+        dataset["w"].attrs["units"] = "m s-1"
+    dataset.to_netcdf(path)

--- a/app/backend/tests/test_trade_cumulus_output_validation.py
+++ b/app/backend/tests/test_trade_cumulus_output_validation.py
@@ -10,15 +10,12 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from cloud_chamber.bomex_case import (
-    CM1_EXECUTABLE_SHA256,
-    CM1_SOURCE_MANIFEST_SHA256,
-    CRITICAL_SOURCE_HASHES,
-)
+from cloud_chamber.bomex_case import CM1_SOURCE_MANIFEST_SHA256, CRITICAL_SOURCE_HASHES
 from cloud_chamber.cm1_source_customization import (
     CUSTOM_EXECUTABLE_FILENAME,
 )
 from cloud_chamber.result_ingest import ResultMetadata
+from cloud_chamber.run_cost import ExactNumericalDomain
 from cloud_chamber.run_manifest import (
     AppMetadata,
     ExecutionMetadata,
@@ -38,6 +35,10 @@ from cloud_chamber.trade_cumulus_forcing import (
     TRADE_CUMULUS_FORCING_SCHEMA_VERSION,
     TRADE_CUMULUS_FORCING_TARGET,
 )
+from cloud_chamber.trade_cumulus_forcing_diagnostics import (
+    expected_forcing_profiles,
+    forcing_diagnostic_contract,
+)
 from cloud_chamber.trade_cumulus_output_validation import (
     TradeCumulusOutputValidationError,
     clear_trade_cumulus_output_validation_cache,
@@ -51,10 +52,17 @@ from cloud_chamber.variation_envelope import (
     immutable_layer,
 )
 
+_CANONICAL_EXECUTABLE_BYTES = b"approved canonical executable"
+_CANONICAL_EXECUTABLE_SHA256 = hashlib.sha256(_CANONICAL_EXECUTABLE_BYTES).hexdigest()
+
 
 @pytest.fixture(autouse=True)
-def _clear_cache() -> None:
+def _clear_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     clear_trade_cumulus_output_validation_cache()
+    monkeypatch.setattr(
+        "cloud_chamber.trade_cumulus_attempt_provenance.CM1_EXECUTABLE_SHA256",
+        _CANONICAL_EXECUTABLE_SHA256,
+    )
 
 
 def test_valid_output_is_cached_and_cloud_free_response_is_available(
@@ -82,7 +90,8 @@ def test_valid_output_is_cached_and_cloud_free_response_is_available(
     assert first["history_count"] == 3
     assert first["cloud_response_required"] is False
     assert first["resolved_fields"]["w"] == "w"
-    assert calls == 3
+    assert first["forcing_diagnostics"]["file_count"] == 3
+    assert calls == 6
 
 
 @pytest.mark.parametrize(
@@ -101,6 +110,14 @@ def test_valid_output_is_cached_and_cloud_free_response_is_available(
         ("escaped_output", "escapes the accepted attempt directory"),
         ("wrong_surface_flux", "does not match the reviewed target"),
         ("wrong_provenance", "approved source manifest"),
+        ("missing_diagnostic", "forcing diagnostic histories"),
+        ("wrong_diagnostic_time", "exact retained cadence"),
+        ("missing_diagnostic_field", "Required forcing diagnostic field"),
+        ("wrong_diagnostic_units", "unsupported units"),
+        ("wrong_diagnostic_profile", "reviewed forcing profile"),
+        ("wrong_canonical_command", "approved configured executable"),
+        ("tampered_canonical_executable", "executable identity"),
+        ("wrong_launch_executable_hash", "executable identity"),
     ],
 )
 def test_invalid_native_output_fails_closed(
@@ -187,6 +204,13 @@ def _artifacts(
     customization_path: Path | None = None
     customization_status: dict[str, Any] | None = None
     execution_command: list[str] = []
+    execution_sha256: str | None = None
+    runtime_run_dir = tmp_path / "cm1-run"
+    runtime_run_dir.mkdir()
+    canonical_executable = runtime_run_dir / "cm1.exe"
+    canonical_executable.write_bytes(_CANONICAL_EXECUTABLE_BYTES)
+    execution_command = [str(canonical_executable)]
+    execution_sha256 = _CANONICAL_EXECUTABLE_SHA256
     if forcing_customization:
         controls = controls.model_copy(
             update={
@@ -221,6 +245,7 @@ def _artifacts(
         executable.write_bytes(b"custom executable")
         executable_sha256 = hashlib.sha256(executable.read_bytes()).hexdigest()
         execution_command = [str(executable)]
+        execution_sha256 = executable_sha256
         customization_status = {
             "schema_version": "cm1_source_customization_status_v1",
             "customization_kind": TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND,
@@ -245,6 +270,7 @@ def _artifacts(
     }
 
     paths: list[Path] = []
+    diagnostic_paths: list[Path] = []
     times = [0.0, 60.0, 120.0]
     if corruption == "wrong_start":
         times[0] = 1.0
@@ -271,6 +297,23 @@ def _artifacts(
             wrong_surface_flux=corruption == "wrong_surface_flux" and index == 2,
         )
         paths.append(path)
+
+    diagnostic_times = [0.0, 60.0, 120.0]
+    if corruption == "wrong_diagnostic_time":
+        diagnostic_times[1] = 61.0
+    for index, time_seconds in enumerate(diagnostic_times, start=1):
+        if corruption == "missing_diagnostic" and index == 2:
+            continue
+        path = run_dir / f"cm1out_diag_{index:06d}.nc"
+        _write_forcing_diagnostic(
+            path,
+            time_seconds=time_seconds,
+            controls=controls,
+            missing_field=corruption == "missing_diagnostic_field" and index == 2,
+            wrong_units=corruption == "wrong_diagnostic_units" and index == 2,
+            wrong_profile=corruption == "wrong_diagnostic_profile" and index == 2,
+        )
+        diagnostic_paths.append(path)
 
     scientific = {
         "controls": controls.model_dump(mode="json"),
@@ -299,6 +342,11 @@ def _artifacts(
             "timestep_seconds": 1.0,
         },
     }
+    exact_numerical = ExactNumericalDomain.model_validate(numerical["exact_domain"])
+    forcing_diagnostics = forcing_diagnostic_contract(
+        duration_seconds=120,
+        numerical=exact_numerical,
+    )
     identity = canonical_payload_sha256(
         {"scientific_design": scientific, "numerical_realization": numerical}
     )
@@ -337,7 +385,10 @@ def _artifacts(
                 ],
             }
         ),
-        world_payload={"controls": controls.model_dump(mode="json")},
+        world_payload={
+            "controls": controls.model_dump(mode="json"),
+            "forcing_diagnostic_contract": forcing_diagnostics,
+        },
         differences=[],
         relationship_classification="replicate_realization",
         run_profile_id="fixture",
@@ -371,8 +422,9 @@ def _artifacts(
                 "source_manifest_sha256": (
                     "0" * 64 if corruption == "wrong_provenance" else CM1_SOURCE_MANIFEST_SHA256
                 ),
-                "executable_sha256": CM1_EXECUTABLE_SHA256,
+                "executable_sha256": _CANONICAL_EXECUTABLE_SHA256,
             },
+            "forcing_diagnostic_contract": forcing_diagnostics,
             "cm1_source_customization_kind": (
                 TRADE_CUMULUS_FORCING_CUSTOMIZATION_KIND if forcing_customization else None
             ),
@@ -389,18 +441,22 @@ def _artifacts(
             ),
             runtime_file_checklist=[str(checklist)],
         ),
-        runtime_paths=RuntimePaths(runtime_home=str(tmp_path)),
+        runtime_paths=RuntimePaths(
+            runtime_home=str(tmp_path),
+            cm1_run_dir=str(runtime_run_dir),
+        ),
         app=AppMetadata(app_version="test", commit="test"),
         lifecycle_state=LifecycleState.COMPLETED,
         validation_status=ValidationStatus.NEEDS_REVIEW,
         provenance=ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
         execution=ExecutionMetadata(
             command=execution_command,
+            executable_sha256=execution_sha256,
             started_at=now,
             finished_at=now,
             exit_code=0,
         ),
-        outputs=OutputMetadata(netcdf_paths=[str(path) for path in paths]),
+        outputs=OutputMetadata(netcdf_paths=[str(path) for path in [*paths, *diagnostic_paths]]),
         required_output_fields=[
             "ql",
             "qv",
@@ -422,7 +478,17 @@ def _artifacts(
         updated_at=now,
         user=UserMetadata(name="Output validation fixture"),
         cm1_source_customization_status=customization_status,
+        expected_outputs=[
+            "native_numbered_cm1_model_netcdf",
+            "cm1_domain_diagnostic_netcdf",
+        ],
     )
+    if corruption == "wrong_canonical_command":
+        manifest.execution.command = [str(run_dir / "other-cm1.exe")]
+    elif corruption == "tampered_canonical_executable":
+        canonical_executable.write_bytes(b"tampered")
+    elif corruption == "wrong_launch_executable_hash":
+        manifest.execution.executable_sha256 = "f" * 64
     metadata = ResultMetadata(
         result_id="result-trade-output-validation",
         run_id=manifest.run_id,
@@ -435,7 +501,7 @@ def _artifacts(
         source_model="CM1",
         required_output_fields=manifest.required_output_fields,
         model_output_paths=[str(path) for path in paths],
-        netcdf_paths=[str(path) for path in paths],
+        netcdf_paths=[str(path) for path in [*paths, *diagnostic_paths]],
         model_output_file_count=3,
         time_steps=3,
         first_output_time_seconds=0.0,
@@ -531,4 +597,52 @@ def _write_history(
         dataset[field].attrs["units"] = "m s-1"
     if "w" in dataset:
         dataset["w"].attrs["units"] = "m s-1"
+    dataset.to_netcdf(path)
+
+
+def _write_forcing_diagnostic(
+    path: Path,
+    *,
+    time_seconds: float,
+    controls: Any,
+    missing_field: bool,
+    wrong_units: bool,
+    wrong_profile: bool,
+) -> None:
+    zh_m = np.asarray([50.0, 150.0])
+    zf_m = np.asarray([0.0, 100.0, 200.0])
+    profiles = expected_forcing_profiles(controls, zh_m=zh_m, zf_m=zf_m)
+    if wrong_profile:
+        profiles["wprof"] = profiles["wprof"].copy()
+        profiles["wprof"][1] += 0.01
+    data_vars: dict[str, Any] = {
+        "wprof": (
+            ("time", "zf", "yh", "xh"),
+            profiles["wprof"].reshape(1, 3, 1, 1).astype(np.float32),
+        ),
+        "ptb_frc": (
+            ("time", "zh", "yh", "xh"),
+            profiles["ptb_frc"].reshape(1, 2, 1, 1).astype(np.float32),
+        ),
+        "qvb_frc": (
+            ("time", "zh", "yh", "xh"),
+            profiles["qvb_frc"].reshape(1, 2, 1, 1).astype(np.float32),
+        ),
+    }
+    if missing_field:
+        data_vars.pop("qvb_frc")
+    dataset = xr.Dataset(
+        data_vars,
+        coords={
+            "time": ("time", [time_seconds], {"units": "seconds"}),
+            "zh": ("zh", zh_m, {"units": "m"}),
+            "zf": ("zf", zf_m, {"units": "m"}),
+            "yh": ("yh", [0.0], {"units": "degree_north"}),
+            "xh": ("xh", [0.0], {"units": "degree_east"}),
+        },
+    )
+    dataset["wprof"].attrs["units"] = "cm/s" if wrong_units else "m/s"
+    dataset["ptb_frc"].attrs["units"] = "K/s"
+    if "qvb_frc" in dataset:
+        dataset["qvb_frc"].attrs["units"] = "g/g/s"
     dataset.to_netcdf(path)

--- a/app/backend/tests/test_trade_cumulus_recipes.py
+++ b/app/backend/tests/test_trade_cumulus_recipes.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+from pydantic import ValidationError
+
+from cloud_chamber.run_cost import profile_by_id
+from cloud_chamber.trade_cumulus_recipes import (
+    RECIPE_ID,
+    TARGET_TOLERANCE,
+    ResolvedTradeCumulusRecipe,
+    TradeCumulusControls,
+    default_controls,
+    normalize_controls,
+    resolve_trade_cumulus_recipe,
+)
+
+
+def _resolve(
+    controls: TradeCumulusControls,
+    *,
+    parent: TradeCumulusControls | None = None,
+    profile_id: str = "trade_cumulus_standard_v1",
+) -> ResolvedTradeCumulusRecipe:
+    return resolve_trade_cumulus_recipe(
+        controls=controls,
+        parent_controls=parent or default_controls(),
+        catalog_profile=profile_by_id(profile_id),
+    )
+
+
+def test_reference_recipe_resolves_exact_direct_targets() -> None:
+    controls = default_controls()
+
+    resolved = _resolve(controls)
+
+    assert resolved.recipe_id == RECIPE_ID
+    assert resolved.blocking_errors == []
+    assert resolved.warnings == []
+    for field, requested in controls.model_dump(mode="json").items():
+        assert resolved.achieved_controls[field] == pytest.approx(
+            requested,
+            abs=0.1 if field.endswith("_deg") else TARGET_TOLERANCE,
+        )
+    assert resolved.differences == []
+    assert resolved.diagnostics.inversion_top_m_agl == pytest.approx(1_480)
+    assert resolved.observation_plan.expected_history_count == 121
+
+
+@pytest.mark.parametrize(
+    ("field", "minimum", "maximum"),
+    [
+        ("surface_sensible_heat_flux_k_m_s", -0.020, 0.050),
+        ("surface_moisture_flux_g_kg_m_s", -0.10, 0.25),
+        ("sub_inversion_total_water_g_kg", 0.0, 25.0),
+        ("inversion_base_m_agl", 300.0, 4_000.0),
+        ("inversion_thickness_m", 50.0, 2_000.0),
+        ("inversion_strength_k", -5.0, 20.0),
+        ("free_tropospheric_rh_percent", 0.0, 100.0),
+        ("cloud_layer_shear_m_s", 0.0, 50.0),
+        ("cloud_layer_shear_direction_deg", 0.0, 360.0),
+        ("large_scale_vertical_motion_m_s", -0.050, 0.050),
+        ("temperature_tendency_k_day", -20.0, 10.0),
+        ("total_water_tendency_g_kg_day", -20.0, 10.0),
+    ],
+)
+def test_direct_control_envelopes_accept_named_bounds(
+    field: str,
+    minimum: float,
+    maximum: float,
+) -> None:
+    baseline = default_controls().model_dump(mode="json")
+
+    TradeCumulusControls.model_validate({**baseline, field: minimum})
+    TradeCumulusControls.model_validate({**baseline, field: maximum})
+    with pytest.raises(ValidationError):
+        TradeCumulusControls.model_validate({**baseline, field: math.nextafter(minimum, -math.inf)})
+    with pytest.raises(ValidationError):
+        TradeCumulusControls.model_validate({**baseline, field: math.nextafter(maximum, math.inf)})
+
+
+def test_unusual_atmosphere_and_reversed_forcing_warn_without_science_block() -> None:
+    controls = TradeCumulusControls(
+        surface_sensible_heat_flux_k_m_s=-0.01,
+        surface_moisture_flux_g_kg_m_s=-0.05,
+        sub_inversion_total_water_g_kg=18.0,
+        inversion_base_m_agl=500.0,
+        inversion_thickness_m=700.0,
+        inversion_strength_k=-2.0,
+        free_tropospheric_rh_percent=98.0,
+        cloud_layer_shear_m_s=35.0,
+        cloud_layer_shear_direction_deg=225.0,
+        large_scale_vertical_motion_m_s=0.02,
+        temperature_tendency_k_day=4.0,
+        total_water_tendency_g_kg_day=5.0,
+    )
+
+    resolved = _resolve(controls)
+
+    assert resolved.blocking_errors == []
+    assert len(resolved.warnings) == 8
+    assert "Static instability possible" in resolved.diagnostics.labels
+    assert "Initial saturation present" in resolved.diagnostics.labels
+    assert "Large-scale ascent" in resolved.diagnostics.labels
+    assert resolved.achieved_controls["cloud_layer_shear_m_s"] == pytest.approx(35.0)
+    assert resolved.achieved_controls["cloud_layer_shear_direction_deg"] == pytest.approx(225.0)
+
+
+def test_profile_top_blocks_an_unattainable_inversion_without_clipping() -> None:
+    controls = default_controls().model_copy(
+        update={
+            "inversion_base_m_agl": 2_500.0,
+            "inversion_thickness_m": 1_000.0,
+        }
+    )
+
+    resolved = _resolve(controls)
+
+    assert any("selected run profile ends at 3,000 m" in item for item in resolved.blocking_errors)
+    assert resolved.controls["inversion_base_m_agl"] == 2_500.0
+    assert resolved.controls["inversion_thickness_m"] == 1_000.0
+    assert resolved.diagnostics.inversion_top_m_agl == 3_500.0
+    assert any("contains no valid sampling layer" in item for item in resolved.blocking_errors)
+
+
+def test_zero_shear_direction_is_canonicalized_without_hidden_state() -> None:
+    controls = default_controls().model_copy(
+        update={
+            "cloud_layer_shear_m_s": 0.0,
+            "cloud_layer_shear_direction_deg": 240.0,
+        }
+    )
+
+    normalized = normalize_controls(controls)
+    resolved = _resolve(controls)
+
+    assert normalized.cloud_layer_shear_direction_deg == 0.0
+    assert resolved.achieved_controls["cloud_layer_shear_m_s"] == pytest.approx(0.0)
+    assert resolved.achieved_controls["cloud_layer_shear_direction_deg"] == pytest.approx(0.0)
+
+
+def test_lineage_differences_compare_child_to_parent_not_reference() -> None:
+    parent = default_controls().model_copy(update={"surface_moisture_flux_g_kg_m_s": 0.078})
+    child = parent.model_copy(
+        update={
+            "surface_moisture_flux_g_kg_m_s": 0.090,
+            "temperature_tendency_k_day": -3.0,
+        }
+    )
+
+    resolved = _resolve(child, parent=parent)
+
+    differences = {difference.path: difference for difference in resolved.differences}
+    moisture = differences["controls.surface_moisture_flux_g_kg_m_s"]
+    assert moisture.before == pytest.approx(0.078)
+    assert moisture.after == pytest.approx(0.090)
+    assert moisture.units == "g kg^-1 m s^-1"
+    assert "controls.temperature_tendency_k_day" in differences
+    assert "controls.surface_sensible_heat_flux_k_m_s" not in differences
+
+
+def test_all_profiles_use_the_approved_recipe_and_field_inventory() -> None:
+    expected = {
+        "trade_cumulus_quick_v1": (10_800, 180, 61),
+        "trade_cumulus_standard_v1": (14_400, 120, 121),
+        "trade_cumulus_full_cycle_v1": (21_600, 120, 181),
+        "trade_cumulus_presentation_v1": (14_400, 60, 241),
+        "trade_cumulus_extended_v1": (14_400, 120, 121),
+    }
+
+    for profile_id, contract in expected.items():
+        profile = profile_by_id(profile_id)
+        resolved = _resolve(default_controls(), profile_id=profile_id)
+        plan = resolved.observation_plan
+        assert profile.recipe_id == RECIPE_ID
+        assert (
+            plan.duration_seconds,
+            plan.output_cadence_seconds,
+            plan.expected_history_count,
+        ) == contract
+        assert {"ql", "qv", "th", "prs", "u", "v", "w", "hfx", "qfx"}.issubset(
+            plan.retained_field_inventory
+        )
+
+    assert any(
+        "uncharacterized" in item
+        for item in _resolve(
+            default_controls(), profile_id="trade_cumulus_extended_v1"
+        ).blocking_errors
+    )

--- a/app/backend/tests/test_trade_cumulus_recipes.py
+++ b/app/backend/tests/test_trade_cumulus_recipes.py
@@ -54,7 +54,7 @@ def test_reference_recipe_resolves_exact_direct_targets() -> None:
         ("surface_sensible_heat_flux_k_m_s", -0.020, 0.050),
         ("surface_moisture_flux_g_kg_m_s", -0.10, 0.25),
         ("sub_inversion_total_water_g_kg", 0.0, 25.0),
-        ("inversion_base_m_agl", 300.0, 4_000.0),
+        ("inversion_base_m_agl", 300.0, 2_800.0),
         ("inversion_thickness_m", 50.0, 2_000.0),
         ("inversion_strength_k", -5.0, 20.0),
         ("free_tropospheric_rh_percent", 0.0, 100.0),

--- a/app/backend/tests/test_trade_cumulus_variations.py
+++ b/app/backend/tests/test_trade_cumulus_variations.py
@@ -39,8 +39,11 @@ from cloud_chamber.run_manifest import (
 from cloud_chamber.settings import CloudChamberSettings
 from cloud_chamber.trade_cumulus_recipes import TradeCumulusControls
 from cloud_chamber.trade_cumulus_variations import (
+    EXTENDED_CHARACTERIZATION_AUTHORIZATION_ID,
+    TradeCumulusExtendedCharacterizationRequest,
     TradeCumulusVariationError,
     TradeCumulusVariationRequest,
+    create_trade_cumulus_extended_characterization,
     create_trade_cumulus_variation,
     preflight_trade_cumulus_variation,
     preview_trade_cumulus_variation,
@@ -119,6 +122,61 @@ def test_preview_blocks_unattainable_vertical_domain_without_clipping(
 
     assert any("run profile ends" in error for error in preview.blocking_errors)
     assert preview.diagnostics["inversion_top_m_agl"] == 3_000
+
+
+def test_normal_extended_profile_remains_blocked(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    _write_parent(settings)
+
+    preview = preview_trade_cumulus_variation(
+        settings,
+        TradeCumulusVariationRequest(
+            parent_simulation_id=REFERENCE_SIMULATION_ID,
+            simulation_name="Ordinary Extended request",
+            run_profile_id="trade_cumulus_extended_v1",
+            controls=TradeCumulusControls(),
+        ),
+    )
+
+    assert any("uncharacterized" in error for error in preview.blocking_errors)
+
+
+def test_pm_authorized_extended_reference_characterization_packages_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_parent(settings)
+    _patch_package_environment(tmp_path, monkeypatch)
+
+    package = create_trade_cumulus_extended_characterization(
+        settings,
+        TradeCumulusExtendedCharacterizationRequest(
+            authorization_id=EXTENDED_CHARACTERIZATION_AUTHORIZATION_ID
+        ),
+    )
+    manifest = load_run_manifest(Path(package.manifest_path))
+    authorization = manifest.run_configuration["characterization_authorization"]
+
+    assert authorization["issue_number"] == 448
+    assert authorization["ordinary_extended_profile_enabled"] is False
+    assert manifest.run_configuration["parent_simulation_id"] == REFERENCE_SIMULATION_ID
+    assert manifest.run_configuration["launch_specification"]["profile_id"] == (
+        "trade_cumulus_extended_v1"
+    )
+    assert manifest.controls == TradeCumulusControls().model_dump(mode="json")
+    assert manifest.manual_validation_status == (
+        "pm_authorized_extended_reference_characterization_packaged"
+    )
+    assert package.preflight["passed"] is True
+    assert package.envelope.world_payload["characterization_authorization"] == authorization
+    with pytest.raises(TradeCumulusVariationError, match="already been used"):
+        create_trade_cumulus_extended_characterization(
+            settings,
+            TradeCumulusExtendedCharacterizationRequest(
+                authorization_id=EXTENDED_CHARACTERIZATION_AUTHORIZATION_ID
+            ),
+        )
 
 
 def test_package_persists_exact_inputs_shared_envelope_and_retry_identity(
@@ -229,6 +287,10 @@ def test_completed_retries_promote_one_backing_and_support_descendant_creation(
     monkeypatch.setattr(
         "cloud_chamber.cloud_worlds.validate_trade_cumulus_variation_outputs",
         lambda _manifest, _metadata: {"passed": True},
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.cloud_worlds.validate_trade_cumulus_attempt_provenance",
+        lambda _manifest: {"passed": True},
     )
 
     world = trade_cumulus_world_detail(settings)
@@ -430,23 +492,34 @@ def _patch_package_environment(
         "cloud_chamber.trade_cumulus_variations.collect_cm1_provenance",
         lambda _settings: provenance,
     )
-    monkeypatch.setattr(
-        "cloud_chamber.trade_cumulus_variations._render_namelist",
-        lambda _reference, controls, _profile: (
-            "nx = 96,\n"
-            "ny = 96,\n"
-            "nz = 100,\n"
-            "dx = 66.66666667,\n"
-            "dy = 66.66666667,\n"
-            "dz = 30,\n"
-            "dtl = 2,\n"
+
+    def render_namelist(
+        _reference: str,
+        controls: TradeCumulusControls,
+        profile_id: str,
+    ) -> str:
+        extended = profile_id == "trade_cumulus_extended_v1"
+        return (
+            f"nx = {128 if extended else 96},\n"
+            f"ny = {128 if extended else 96},\n"
+            f"nz = {75 if extended else 100},\n"
+            f"dx = {100 if extended else 66.66666667},\n"
+            f"dy = {100 if extended else 66.66666667},\n"
+            f"dz = {40 if extended else 30},\n"
+            f"dtl = {3 if extended else 2},\n"
             "timax = 14400,\n"
-            "tapfrq = 60,\n"
+            f"tapfrq = {120 if extended else 60},\n"
+            "dodomaindiag = .true.,\n"
+            "diagfrq = 60,\n"
             "isnd = 7,\n"
             "iwnd = 0,\n"
             f"cnst_shflx = {controls.surface_sensible_heat_flux_k_m_s:.12e},\n"
             f"cnst_lhflx = {controls.surface_moisture_flux_g_kg_m_s / 1000:.12e},\n"
-        ),
+        )
+
+    monkeypatch.setattr(
+        "cloud_chamber.trade_cumulus_variations._render_namelist",
+        render_namelist,
     )
     monkeypatch.setattr(
         "cloud_chamber.run_cost.shutil.disk_usage",

--- a/app/backend/tests/test_trade_cumulus_variations.py
+++ b/app/backend/tests/test_trade_cumulus_variations.py
@@ -7,7 +7,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from cloud_chamber.bomex_case import CM1Provenance
+from cloud_chamber.bomex_case import (
+    CM1_EXECUTABLE_SHA256,
+    CM1_SOURCE_MANIFEST_SHA256,
+    CM1Provenance,
+)
 from cloud_chamber.cloud_worlds import (
     PRESENTATION_BASELINE_RESULT_ID,
     PRESENTATION_BASELINE_RUN_ID,
@@ -250,6 +254,43 @@ def test_completed_retries_promote_one_backing_and_support_descendant_creation(
     assert child.controls.surface_moisture_flux_g_kg_m_s == 0.09
 
 
+def test_cross_parent_attempt_collision_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_parent(settings)
+    _patch_package_environment(tmp_path, monkeypatch)
+    request = _request(controls=TradeCumulusControls(surface_moisture_flux_g_kg_m_s=0.09))
+    first = create_trade_cumulus_variation(settings, request)
+    second = create_trade_cumulus_variation(settings, request)
+    second_path = Path(second.manifest_path)
+    second_manifest = load_run_manifest(second_path)
+    second_envelope = VariationEnvelope.model_validate(
+        second_manifest.run_configuration["variation_envelope"]
+    ).model_copy(update={"parent_simulation_id": "trade_cumulus_more_moisture"})
+    second_manifest.run_configuration["variation_envelope"] = second_envelope.model_dump(
+        mode="json"
+    )
+    second_manifest.run_configuration["parent_simulation_id"] = "trade_cumulus_more_moisture"
+    write_run_manifest(second_path, second_manifest)
+    _complete_package(first.manifest_path)
+    _complete_package(second.manifest_path)
+    monkeypatch.setattr(
+        "cloud_chamber.cloud_worlds.validate_trade_cumulus_variation_outputs",
+        lambda _manifest, _metadata: {"passed": True},
+    )
+
+    world = trade_cumulus_world_detail(settings)
+
+    assert all(record.simulation_id != first.simulation_id for record in world.simulations)
+    conflict = next(
+        record for record in world.lab_history if record.run_id in {first.run_id, second.run_id}
+    )
+    assert conflict.technical_state == "conflict"
+    assert "canonical intended Simulation contract" in conflict.technical_state_message
+
+
 def _request(*, controls: TradeCumulusControls) -> TradeCumulusVariationRequest:
     return TradeCumulusVariationRequest(
         parent_simulation_id=REFERENCE_SIMULATION_ID,
@@ -370,11 +411,11 @@ def _patch_package_environment(
         source_tree_path=str(source_root),
         run_directory_path=str(tmp_path / "cm1-run"),
         executable_path=str(tmp_path / "cm1.exe"),
-        executable_sha256="a" * 64,
+        executable_sha256=CM1_EXECUTABLE_SHA256,
         readme_namelist_path=str(reference_namelist),
         readme_namelist_sha256="b" * 64,
         source_manifest_method="test",
-        source_manifest_sha256="c" * 64,
+        source_manifest_sha256=CM1_SOURCE_MANIFEST_SHA256,
         critical_source_sha256={"src/base.F": "d" * 64},
         bundled_bomex_namelist_path=str(reference_namelist),
         bundled_bomex_namelist_sha256="e" * 64,

--- a/app/backend/tests/test_trade_cumulus_variations.py
+++ b/app/backend/tests/test_trade_cumulus_variations.py
@@ -1,0 +1,470 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from cloud_chamber.bomex_case import CM1Provenance
+from cloud_chamber.cloud_worlds import (
+    PRESENTATION_BASELINE_RESULT_ID,
+    PRESENTATION_BASELINE_RUN_ID,
+    PRESENTATION_FIXED_ASSUMPTIONS_SHA256,
+    REFERENCE_SIMULATION_ID,
+    trade_cumulus_world_detail,
+)
+from cloud_chamber.result_ingest import ResultMetadata
+from cloud_chamber.run_manifest import (
+    AppMetadata,
+    ExecutionMetadata,
+    GeneratedInputs,
+    LifecycleState,
+    OutputMetadata,
+    ProductState,
+    ProvenanceMetadata,
+    RunManifest,
+    RuntimePaths,
+    ScenarioReference,
+    UserMetadata,
+    ValidationStatus,
+    load_run_manifest,
+    write_run_manifest,
+)
+from cloud_chamber.settings import CloudChamberSettings
+from cloud_chamber.trade_cumulus_recipes import TradeCumulusControls
+from cloud_chamber.trade_cumulus_variations import (
+    TradeCumulusVariationError,
+    TradeCumulusVariationRequest,
+    create_trade_cumulus_variation,
+    preflight_trade_cumulus_variation,
+    preview_trade_cumulus_variation,
+    trade_cumulus_variation_template,
+)
+from cloud_chamber.variation_envelope import VariationEnvelope
+
+
+def test_template_inherits_absolute_parent_controls_and_all_profiles(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    _write_parent(settings)
+
+    template = trade_cumulus_variation_template(settings, REFERENCE_SIMULATION_ID)
+
+    assert template.can_create_variation is True
+    assert template.controls == TradeCumulusControls()
+    assert template.canonical_reference_controls == TradeCumulusControls()
+    assert template.default_run_profile_id == "trade_cumulus_presentation_v1"
+    assert {estimate.profile.role for estimate in template.run_profiles} == {
+        "Quick",
+        "Standard",
+        "Full-cycle",
+        "Presentation",
+        "Extended",
+    }
+
+
+def test_preview_uses_parent_relative_differences_and_warns_without_blocking(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_parent(settings)
+    controls = TradeCumulusControls(
+        surface_sensible_heat_flux_k_m_s=-0.01,
+        surface_moisture_flux_g_kg_m_s=-0.05,
+        inversion_strength_k=-2.0,
+        free_tropospheric_rh_percent=98.0,
+        cloud_layer_shear_m_s=35.0,
+        large_scale_vertical_motion_m_s=0.02,
+        temperature_tendency_k_day=3.0,
+        total_water_tendency_g_kg_day=2.0,
+    )
+
+    preview = preview_trade_cumulus_variation(
+        settings,
+        _request(controls=controls),
+    )
+
+    assert preview.blocking_errors == []
+    assert preview.relationship_classification == "multi_factor_physical_variation"
+    assert preview.canonical_reference_controls["surface_moisture_flux_g_kg_m_s"] == 0.052
+    assert preview.parent_controls["surface_moisture_flux_g_kg_m_s"] == 0.052
+    assert preview.resolved_controls["surface_moisture_flux_g_kg_m_s"] == -0.05
+    assert any("downward" in warning for warning in preview.warnings)
+    assert any("reverses the inversion" in warning for warning in preview.warnings)
+    assert any("reversed to ascent" in warning for warning in preview.warnings)
+    assert len(preview.sounding_profile) > 20
+    assert len(preview.forcing_profile) > 20
+
+
+def test_preview_blocks_unattainable_vertical_domain_without_clipping(
+    tmp_path: Path,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_parent(settings)
+
+    preview = preview_trade_cumulus_variation(
+        settings,
+        _request(
+            controls=TradeCumulusControls(
+                inversion_base_m_agl=2_000,
+                inversion_thickness_m=1_000,
+            )
+        ),
+    )
+
+    assert any("run profile ends" in error for error in preview.blocking_errors)
+    assert preview.diagnostics["inversion_top_m_agl"] == 3_000
+
+
+def test_package_persists_exact_inputs_shared_envelope_and_retry_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_parent(settings)
+    _patch_package_environment(tmp_path, monkeypatch)
+    request = _request(controls=TradeCumulusControls(surface_moisture_flux_g_kg_m_s=0.09))
+
+    first = create_trade_cumulus_variation(settings, request)
+    second = create_trade_cumulus_variation(settings, request)
+    manifest = load_run_manifest(Path(first.manifest_path))
+    namelist = Path(manifest.generated_inputs.namelist_input or "").read_text()
+    sounding = Path(manifest.generated_inputs.input_sounding or "").read_text()
+
+    assert first.simulation_id == second.simulation_id
+    assert first.run_id != second.run_id
+    assert first.envelope.package_identity_sha256 == second.envelope.package_identity_sha256
+    assert first.envelope.relationship_classification == "controlled_physical_variation"
+    assert second.envelope.attempts[-1].relationship == "unchanged_retry"
+    assert manifest.lifecycle_state == LifecycleState.PACKAGED
+    assert manifest.recipe_id == "canonical_bomex_trade_cumulus"
+    assert manifest.run_configuration["variation_envelope"]["availability_state"] == "packaged"
+    assert manifest.run_configuration["launch_specification"]["profile_id"] == (
+        "trade_cumulus_presentation_v1"
+    )
+    assert manifest.run_configuration["launch_review_snapshot_id"]
+    assert "cnst_lhflx = 9.000000000000e-05" in namelist
+    assert "isnd = 7" in namelist
+    assert len(sounding.splitlines()) > 20
+    assert first.preflight["passed"] is True
+    assert preflight_trade_cumulus_variation(Path(first.manifest_path))["passed"] is True
+    assert not list(Path(first.package_dir).glob("cm1out*"))
+
+
+def test_package_forcing_customization_records_absolute_signed_targets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_parent(settings)
+    source_path = _patch_package_environment(tmp_path, monkeypatch)
+    controls = TradeCumulusControls(
+        surface_moisture_flux_g_kg_m_s=0.09,
+        large_scale_vertical_motion_m_s=0.02,
+        temperature_tendency_k_day=4.0,
+        total_water_tendency_g_kg_day=-6.0,
+    )
+
+    package = create_trade_cumulus_variation(settings, _request(controls=controls))
+    manifest = load_run_manifest(Path(package.manifest_path))
+    artifact = Path(manifest.generated_inputs.cm1_source_customization or "").read_text()
+
+    assert source_path.name == "base.F"
+    assert '"vertical_motion_m_s": 0.02' in artifact
+    assert '"temperature_tendency_k_day": 4.0' in artifact
+    assert '"total_water_tendency_g_kg_day": -6.0' in artifact
+    assert manifest.run_configuration["cm1_source_customization_kind"] == (
+        "trade_cumulus_forcing_v1"
+    )
+
+
+def test_preflight_rejects_self_consistent_but_wrong_generated_sounding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_parent(settings)
+    _patch_package_environment(tmp_path, monkeypatch)
+    package = create_trade_cumulus_variation(
+        settings,
+        _request(
+            controls=TradeCumulusControls(
+                sub_inversion_total_water_g_kg=18.0,
+            )
+        ),
+    )
+    manifest_path = Path(package.manifest_path)
+    manifest = load_run_manifest(manifest_path)
+    sounding_path = Path(manifest.generated_inputs.input_sounding or "")
+    sounding_path.write_text(sounding_path.read_text() + "\n# tampered after review\n")
+    generated_hashes = dict(manifest.run_configuration["generated_input_sha256"])
+    generated_hashes["input_sounding"] = hashlib.sha256(sounding_path.read_bytes()).hexdigest()
+    manifest.run_configuration["generated_input_sha256"] = generated_hashes
+    write_run_manifest(manifest_path, manifest)
+
+    with pytest.raises(
+        TradeCumulusVariationError,
+        match="sounding_matches_reviewed_contract.*False",
+    ):
+        preflight_trade_cumulus_variation(manifest_path)
+
+
+def test_completed_retries_promote_one_backing_and_support_descendant_creation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings(tmp_path)
+    _write_parent(settings)
+    _patch_package_environment(tmp_path, monkeypatch)
+    request = _request(controls=TradeCumulusControls(surface_moisture_flux_g_kg_m_s=0.09))
+    first = create_trade_cumulus_variation(settings, request)
+    second = create_trade_cumulus_variation(settings, request)
+    _complete_package(first.manifest_path)
+    _complete_package(second.manifest_path)
+    monkeypatch.setattr(
+        "cloud_chamber.cloud_worlds.validate_trade_cumulus_variation_outputs",
+        lambda _manifest, _metadata: {"passed": True},
+    )
+
+    world = trade_cumulus_world_detail(settings)
+    records = [
+        record for record in world.simulations if record.simulation_id == first.simulation_id
+    ]
+
+    assert len(records) == 1
+    assert records[0].run_id == first.run_id
+    assert records[0].attempt_count == 2
+    assert records[0].can_create_variation is True
+    promoted = load_run_manifest(Path(first.manifest_path))
+    envelope = VariationEnvelope.model_validate(promoted.run_configuration["variation_envelope"])
+    assert [attempt.run_id for attempt in envelope.attempts] == [
+        first.run_id,
+        second.run_id,
+    ]
+    assert [attempt.run_id for attempt in envelope.attempts if attempt.accepted_backing] == [
+        first.run_id
+    ]
+    child = trade_cumulus_variation_template(settings, first.simulation_id)
+    assert child.can_create_variation is True
+    assert child.controls.surface_moisture_flux_g_kg_m_s == 0.09
+
+
+def _request(*, controls: TradeCumulusControls) -> TradeCumulusVariationRequest:
+    return TradeCumulusVariationRequest(
+        parent_simulation_id=REFERENCE_SIMULATION_ID,
+        simulation_name="Direct target experiment",
+        user_question="How do direct atmospheric targets change the cloud field?",
+        run_profile_id="trade_cumulus_presentation_v1",
+        controls=controls,
+    )
+
+
+def _settings(tmp_path: Path) -> CloudChamberSettings:
+    return CloudChamberSettings(
+        runtime_home=tmp_path / "runtime",
+        cm1_root=None,
+        cm1_run_dir=None,
+        cache_dir=tmp_path / "cache",
+        log_dir=tmp_path / "logs",
+    )
+
+
+def _write_parent(settings: CloudChamberSettings) -> None:
+    run_dir = settings.runtime_home / "runs" / PRESENTATION_BASELINE_RUN_ID
+    run_dir.mkdir(parents=True)
+    output = run_dir / "cm1out_000001.nc"
+    output.write_bytes(b"CDF retained parent fixture")
+    namelist = run_dir / "namelist.input"
+    sounding = run_dir / "input_sounding"
+    namelist.write_text("isnd = 7,\n")
+    sounding.write_text("1015.0 298.7 17.0\n0.0 298.7 17.0 -8.75 0.0\n")
+    now = datetime(2026, 7, 28, tzinfo=UTC)
+    manifest_path = run_dir / "run_manifest.json"
+    manifest = RunManifest(
+        run_id=PRESENTATION_BASELINE_RUN_ID,
+        scenario=ScenarioReference(
+            id="bomex_trade_cumulus_baseline_v0",
+            schema_version="test-v1",
+        ),
+        controls={"surface_moisture_flux_g_g_m_s": 5.2e-5},
+        run_configuration={
+            "case_id": "bomex_trade_cumulus_baseline_v0",
+            "product_slice_id": "trade_cumulus_v1",
+            "comparison_group_id": "trade_cumulus_moisture_v1",
+            "surface_moisture_flux_g_g_m_s": 5.2e-5,
+            "fixed_assumptions_sha256": PRESENTATION_FIXED_ASSUMPTIONS_SHA256,
+        },
+        physical_question="Canonical BOMEX parent",
+        expected_diagnostics=[],
+        generated_inputs=GeneratedInputs(
+            run_directory=str(run_dir),
+            manifest_path=str(manifest_path),
+            namelist_input=str(namelist),
+            input_sounding=str(sounding),
+        ),
+        runtime_paths=RuntimePaths(runtime_home=str(settings.runtime_home)),
+        app=AppMetadata(app_version="test", commit="test"),
+        lifecycle_state=LifecycleState.COMPLETED,
+        validation_status=ValidationStatus.VALID,
+        provenance=ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+        created_at=now,
+        updated_at=now,
+        user=UserMetadata(name="Canonical BOMEX Baseline"),
+    )
+    write_run_manifest(manifest_path, manifest)
+    metadata = ResultMetadata(
+        result_id=PRESENTATION_BASELINE_RESULT_ID,
+        run_id=PRESENTATION_BASELINE_RUN_ID,
+        scenario_id="bomex_trade_cumulus_baseline_v0",
+        physical_question="Canonical BOMEX parent",
+        controls={
+            "control_id": "surface_moisture_supply",
+            "control_state": "baseline",
+            "surface_moisture_flux_g_g_m_s": 5.2e-5,
+        },
+        run_configuration={
+            "case_id": "bomex_trade_cumulus_baseline_v0",
+            "product_slice_id": "trade_cumulus_v1",
+            "comparison_group_id": "trade_cumulus_moisture_v1",
+            "control_id": "surface_moisture_supply",
+            "control_state": "baseline",
+            "recipe_candidate_id": "canonical_bomex_baseline",
+            "surface_moisture_flux_g_g_m_s": 5.2e-5,
+            "fixed_assumptions_sha256": PRESENTATION_FIXED_ASSUMPTIONS_SHA256,
+            "cm1_provenance": {
+                "source_manifest_sha256": (
+                    "fbe2367dfcd6d8c55cac4bd03362d8d49f13f80cebd13b36230c20d71119a84e"
+                ),
+                "executable_sha256": (
+                    "5b7304bb04514ec03cf4d6e604bc0b5df6e8076bd4fb53c4b5cf5ea9184cdfd1"
+                ),
+            },
+        },
+        source_lifecycle_state="completed",
+        source_product_state="completed_cm1_result",
+        source_model="CM1",
+        model_output_paths=[str(output)],
+        netcdf_paths=[str(output)],
+        model_output_file_count=1,
+        created_at=now,
+        updated_at=now,
+    )
+    (run_dir / "result_metadata.json").write_text(metadata.to_json_text())
+
+
+def _patch_package_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    source_root = tmp_path / "cm1"
+    source_path = source_root / "src" / "base.F"
+    source_path.parent.mkdir(parents=True)
+    source_path.write_text(_forcing_source_fixture())
+    reference_namelist = tmp_path / "bomex.input"
+    reference_namelist.write_text("fixture\n")
+    provenance = CM1Provenance(
+        release="r21.1",
+        official_tag_commit="tag",
+        official_source_tag="r21.1",
+        source_tree_path=str(source_root),
+        run_directory_path=str(tmp_path / "cm1-run"),
+        executable_path=str(tmp_path / "cm1.exe"),
+        executable_sha256="a" * 64,
+        readme_namelist_path=str(reference_namelist),
+        readme_namelist_sha256="b" * 64,
+        source_manifest_method="test",
+        source_manifest_sha256="c" * 64,
+        critical_source_sha256={"src/base.F": "d" * 64},
+        bundled_bomex_namelist_path=str(reference_namelist),
+        bundled_bomex_namelist_sha256="e" * 64,
+        bundled_bomex_readme_path=str(reference_namelist),
+        bundled_bomex_readme_sha256="f" * 64,
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.trade_cumulus_variations.verified_clean_git_commit",
+        lambda: "implementation-commit",
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.trade_cumulus_variations.collect_cm1_provenance",
+        lambda _settings: provenance,
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.trade_cumulus_variations._render_namelist",
+        lambda _reference, controls, _profile: (
+            "nx = 96,\n"
+            "ny = 96,\n"
+            "nz = 100,\n"
+            "dx = 66.66666667,\n"
+            "dy = 66.66666667,\n"
+            "dz = 30,\n"
+            "dtl = 2,\n"
+            "timax = 14400,\n"
+            "tapfrq = 60,\n"
+            "isnd = 7,\n"
+            "iwnd = 0,\n"
+            f"cnst_shflx = {controls.surface_sensible_heat_flux_k_m_s:.12e},\n"
+            f"cnst_lhflx = {controls.surface_moisture_flux_g_kg_m_s / 1000:.12e},\n"
+        ),
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.run_cost.shutil.disk_usage",
+        lambda _path: SimpleNamespace(free=100 * 1024**3),
+    )
+    return source_path
+
+
+def _complete_package(manifest_path_value: str) -> None:
+    manifest_path = Path(manifest_path_value)
+    manifest = load_run_manifest(manifest_path)
+    run_dir = manifest_path.parent
+    output = run_dir / "cm1out_000001.nc"
+    output.write_bytes(b"CDF completed variation fixture")
+    now = datetime.now(UTC)
+    manifest = manifest.model_copy(
+        update={
+            "lifecycle_state": LifecycleState.COMPLETED,
+            "validation_status": ValidationStatus.NEEDS_REVIEW,
+            "provenance": ProvenanceMetadata(product_state=ProductState.COMPLETED_CM1_RESULT),
+            "execution": ExecutionMetadata(
+                started_at=now,
+                finished_at=now,
+                exit_code=0,
+            ),
+            "outputs": OutputMetadata(netcdf_paths=[str(output)]),
+            "updated_at": now,
+        }
+    )
+    write_run_manifest(manifest_path, manifest)
+    metadata = ResultMetadata(
+        result_id=f"result-{manifest.run_id}",
+        run_id=manifest.run_id,
+        scenario_id=manifest.scenario.id,
+        physical_question=manifest.physical_question,
+        controls=manifest.controls,
+        run_configuration=manifest.run_configuration,
+        source_lifecycle_state="completed",
+        source_product_state="completed_cm1_result",
+        source_model="CM1",
+        required_output_fields=manifest.required_output_fields,
+        model_output_paths=[str(output)],
+        netcdf_paths=[str(output)],
+        model_output_file_count=1,
+        created_at=manifest.created_at,
+        updated_at=now,
+    )
+    (run_dir / "result_metadata.json").write_text(metadata.to_json_text())
+
+
+def _forcing_source_fixture() -> str:
+    return """\
+    IF( testcase .eq. 3 )THEN
+      ! shallow Cu case  (Siebesma et al, 2003, JAS)
+      wmin  =  -0.0065
+      radsfc = -2.0/( 3600.0 * 24.0 )
+      qvsfc  = -1.2e-8
+      qvfrc(k) = -1.2e-8
+    ENDIF
+    IF( testcase .eq. 4 )THEN
+    ENDIF
+"""

--- a/app/backend/tests/test_world_compare.py
+++ b/app/backend/tests/test_world_compare.py
@@ -8,6 +8,7 @@ from cloud_chamber.cloud_worlds import (
     ConfigurationDifference,
     SimulationRecord,
 )
+from cloud_chamber.explore_state import TradeCumulusExploreState
 from cloud_chamber.mountain_wave_terrain_visualization import (
     _ordered_sample_indices,
     _sample_native_grid,
@@ -36,6 +37,12 @@ def _trade_record(
     run_id: str,
     parent_simulation_id: str | None = None,
     difference: ConfigurationDifference | None = None,
+    relationship_classification: str | None = None,
+    source_recipe_id: str | None = "canonical_bomex_trade_cumulus",
+    scientific_design: dict[str, Any] | None = None,
+    numerical_realization: dict[str, Any] | None = None,
+    observation_plan: dict[str, Any] | None = None,
+    configuration: dict[str, Any] | None = None,
 ) -> SimulationRecord:
     return SimulationRecord(
         simulation_id=simulation_id,
@@ -45,6 +52,7 @@ def _trade_record(
         case_id="bomex_trade_cumulus_baseline_v0",
         result_id=f"result-{run_id}",
         run_id=run_id,
+        source_recipe_id=source_recipe_id,
         parent_simulation_id=parent_simulation_id,
         reference_simulation_id="trade_cumulus_canonical_bomex",
         technical_state="available",
@@ -53,6 +61,11 @@ def _trade_record(
         explore_available=True,
         configuration_difference_from_reference=[difference] if difference else None,
         lineage_state="known",
+        relationship_classification=relationship_classification,
+        scientific_design=scientific_design,
+        numerical_realization=numerical_realization,
+        observation_plan=observation_plan,
+        configuration=configuration,
     )
 
 
@@ -140,9 +153,8 @@ def test_trade_compare_uses_the_approved_pair_and_exact_material_difference(
     assert descriptor.selected_right_simulation_id == moisture.simulation_id
     assert descriptor.compatibility is not None
     assert descriptor.compatibility.controlled_pair is True
-    assert (
-        descriptor.compatibility.relationship
-        == "More Moisture is a child of Canonical BOMEX Baseline."
+    assert descriptor.compatibility.relationship == (
+        "More Moisture is a controlled physical variation of Canonical BOMEX Baseline."
     )
     assert descriptor.compatibility.shared_view_ids == ["field", "updraft_lens"]
     assert descriptor.compatibility.physical_plane_link_available is True
@@ -156,6 +168,105 @@ def test_trade_compare_uses_the_approved_pair_and_exact_material_difference(
         simulation.initial_state.world_id == "trade_cumulus"
         for simulation in descriptor.simulations
     )
+
+
+def test_trade_compare_uses_descendant_layers_and_actual_run_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    baseline = _trade_record(
+        simulation_id="trade_cumulus_canonical_bomex",
+        display_name="Canonical BOMEX Baseline",
+        role="reference",
+        run_id="baseline",
+        scientific_design={
+            "controls": {
+                "surface_moisture_flux_g_kg_m_s": 0.052,
+                "inversion_strength_k": 3.7,
+            }
+        },
+        numerical_realization={"grid": "96 x 96 x 100"},
+        observation_plan={
+            "duration_seconds": 14_400,
+            "output_cadence_seconds": 60,
+            "expected_history_count": 241,
+        },
+    )
+    descendant = _trade_record(
+        simulation_id="trade_cumulus_drier_standard",
+        display_name="Drier Standard",
+        role="variation",
+        run_id="drier-standard",
+        parent_simulation_id=baseline.simulation_id,
+        relationship_classification="mixed_variation",
+        difference=ConfigurationDifference(
+            path="scientific_design.controls.surface_moisture_flux_g_kg_m_s",
+            label="Surface moisture flux",
+            category="atmospheric",
+            left_value=0.052,
+            right_value=0.01,
+            units="g/kg m/s",
+            material=True,
+        ),
+        scientific_design={
+            "controls": {
+                "surface_moisture_flux_g_kg_m_s": 0.01,
+                "inversion_strength_k": 3.7,
+            }
+        },
+        numerical_realization={"grid": "64 x 64 x 75"},
+        observation_plan={
+            "duration_seconds": 10_800,
+            "output_cadence_seconds": 180,
+            "expected_history_count": 61,
+        },
+        configuration={
+            "duration_seconds": 10_800,
+            "output_cadence_seconds": 180,
+            "domain": {
+                "nx": 64,
+                "ny": 64,
+                "nz": 75,
+                "dx_m": 100,
+                "dy_m": 100,
+                "dz_m": 40,
+                "model_top_m": 3_000,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "cloud_chamber.world_compare.trade_cumulus_world_detail",
+        lambda _settings: SimpleNamespace(
+            display_name="Trade Cumulus",
+            simulations=[baseline, descendant],
+            reference_simulation=baseline,
+            featured_comparison=SimpleNamespace(
+                more_moisture_simulation_id=descendant.simulation_id
+            ),
+        ),
+    )
+
+    descriptor = world_compare_descriptor(
+        _settings(tmp_path),
+        world_slug="trade-cumulus",
+        left_simulation_id=baseline.simulation_id,
+        right_simulation_id=descendant.simulation_id,
+    )
+
+    assert descriptor.compatibility is not None
+    assert descriptor.compatibility.controlled_pair is False
+    assert "mixed variation" in descriptor.compatibility.relationship
+    assert "both changed" in descriptor.compatibility.controlled_pair_message
+    descendant_descriptor = next(
+        item for item in descriptor.simulations if item.simulation_id == descendant.simulation_id
+    )
+    assert (descendant_descriptor.grid.nx, descendant_descriptor.grid.nz) == (64, 75)
+    assert descendant_descriptor.grid.x_extent_km == (-3.2, 3.2)
+    assert descendant_descriptor.time.saved_output_count == 61
+    assert descendant_descriptor.initial_state.model_time_seconds == 10_800
+    assert isinstance(descendant_descriptor.initial_state, TradeCumulusExploreState)
+    assert descendant_descriptor.initial_state.slice_native_index == 32
+    assert descriptor.material_differences[0].left_value == 0.052
+    assert descriptor.material_differences[0].right_value == 0.01
 
 
 def test_mountain_compare_is_structural_and_keeps_unknown_distinct_from_equal(

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -855,6 +855,471 @@ async function mockTradeCumulusWorld(page: Parameters<typeof mockCloudChamberApi
   );
 }
 
+const tradeVariationReferenceControls = {
+  surface_sensible_heat_flux_k_m_s: 0.008,
+  surface_moisture_flux_g_kg_m_s: 0.052,
+  sub_inversion_total_water_g_kg: 16.65,
+  inversion_base_m_agl: 520,
+  inversion_thickness_m: 960,
+  inversion_strength_k: 3.7,
+  free_tropospheric_rh_percent: 41,
+  cloud_layer_shear_m_s: 4.14,
+  cloud_layer_shear_direction_deg: 0,
+  cloud_layer_mean_u_m_s: -7.5,
+  cloud_layer_mean_v_m_s: 0,
+  large_scale_vertical_motion_m_s: -0.0065,
+  temperature_tendency_k_day: -2,
+  total_water_tendency_g_kg_day: -1.0368,
+};
+
+function tradeVariationProfile(
+  profileId: string,
+  role: string,
+  duration: number,
+  cadence: number,
+  histories: number,
+  blocked = false,
+) {
+  return {
+    profile: {
+      schema_version: "1",
+      world_id: "trade_cumulus",
+      world_name: "Trade Cumulus",
+      recipe_id: "canonical_bomex_trade_cumulus",
+      recipe_version: "approved_variation_contract_v1",
+      profile_id: profileId,
+      profile_name: `${role} — Trade Cumulus experiment`,
+      role,
+      numerical_realization: {
+        domain: role === "Extended" ? "12.8 km square" : "6.4 km square",
+        grid: role === "Presentation" ? "96 × 96 × 100" : "64 × 64 × 75",
+        spacing: role === "Presentation" ? "66.7 × 66.7 × 30 m" : "100 × 100 × 40 m",
+        timestep_strategy: role === "Presentation" ? "target 2 s" : "target 3 s",
+        physics_source: "Canonical BOMEX",
+      },
+      observation_plan: {
+        duration_seconds: duration,
+        output_cadence_seconds: cadence,
+        diagnostic_cadence_seconds: null,
+        expected_history_count: histories,
+        retained_field_inventory: ["ql", "qv", "th", "prs", "u", "v", "w"],
+      },
+      expected_runtime_min_seconds: blocked ? null : 900,
+      expected_runtime_max_seconds: blocked ? null : 1800,
+      expected_size_min_bytes: blocked ? null : 1.6 * 1024 ** 3,
+      expected_size_max_bytes: blocked ? null : 2.2 * 1024 ** 3,
+      estimate_basis: blocked ? "uncharacterized" : "scaled_from_measured",
+      confidence: blocked ? "Requires bounded characterization." : "Scaled evidence.",
+      cost_change_reasons: [],
+      scientific_limitations:
+        role === "Quick" ? ["Early response, not a full steady-period assessment."] : [],
+      required_post_run_reserve_bytes: 2 * 1024 ** 3,
+    },
+    current_free_space_bytes: 100 * 1024 ** 3,
+    projected_free_space_bytes: blocked ? null : 97.8 * 1024 ** 3,
+    required_free_space_bytes: blocked ? null : 4.2 * 1024 ** 3,
+    disposition: blocked ? "blocked" : "passes",
+    disposition_reason: blocked
+      ? "This profile is uncharacterized."
+      : "The high estimate fits while preserving the safety margin.",
+  };
+}
+
+function tradeVariationTemplate(parent = worldBaselineSimulation) {
+  const more = parent.simulation_id === worldMoreMoistureSimulation.simulation_id;
+  return {
+    parent_simulation_id: parent.simulation_id,
+    parent_run_id: parent.run_id,
+    parent_display_name: parent.display_name,
+    parent_configuration_source: "Retained source-backed BOMEX atmosphere and forcing",
+    reference_simulation_id: worldBaselineSimulation.simulation_id,
+    recipe_id: "canonical_bomex_trade_cumulus",
+    recipe_name: "Canonical BOMEX Trade Cumulus",
+    recipe_contract_version: "1",
+    controls: {
+      ...tradeVariationReferenceControls,
+      surface_moisture_flux_g_kg_m_s: more ? 0.078 : 0.052,
+    },
+    canonical_reference_controls: tradeVariationReferenceControls,
+    run_profiles: [
+      tradeVariationProfile("trade_cumulus_quick_v1", "Quick", 10_800, 180, 61),
+      tradeVariationProfile("trade_cumulus_standard_v1", "Standard", 14_400, 120, 121),
+      tradeVariationProfile("trade_cumulus_full_cycle_v1", "Full-cycle", 21_600, 120, 181),
+      tradeVariationProfile("trade_cumulus_presentation_v1", "Presentation", 14_400, 60, 241),
+      tradeVariationProfile("trade_cumulus_extended_v1", "Extended", 14_400, 120, 121, true),
+    ],
+    default_run_profile_id: "trade_cumulus_presentation_v1",
+    can_create_variation: true,
+    unavailable_reason: null,
+  };
+}
+
+function tradeVariationPreview(request: {
+  controls: typeof tradeVariationReferenceControls;
+  run_profile_id: string;
+}) {
+  const physical = Object.entries(request.controls).filter(
+    ([key, value]) =>
+      value !==
+      tradeVariationReferenceControls[key as keyof typeof tradeVariationReferenceControls],
+  );
+  const profileChanged = request.run_profile_id !== "trade_cumulus_presentation_v1";
+  const impossible =
+    request.controls.inversion_base_m_agl + request.controls.inversion_thickness_m >= 3_000;
+  const differences = physical.map(([key, value]) => ({
+    path: `controls.${key}`,
+    label:
+      key === "surface_moisture_flux_g_kg_m_s"
+        ? "Surface moisture flux"
+        : key === "surface_sensible_heat_flux_k_m_s"
+          ? "Surface sensible-heat flux"
+          : key.replaceAll("_", " "),
+    before: tradeVariationReferenceControls[key as keyof typeof tradeVariationReferenceControls],
+    after: value,
+    units: null,
+    material: true,
+  }));
+  const cost = request.run_profile_id.includes("extended")
+    ? tradeVariationProfile("trade_cumulus_extended_v1", "Extended", 14_400, 120, 121, true)
+    : request.run_profile_id.includes("standard")
+      ? tradeVariationProfile("trade_cumulus_standard_v1", "Standard", 14_400, 120, 121)
+      : tradeVariationProfile("trade_cumulus_presentation_v1", "Presentation", 14_400, 60, 241);
+  return {
+    requested_controls: request.controls,
+    resolved_controls: request.controls,
+    canonical_reference_controls: tradeVariationReferenceControls,
+    parent_controls: tradeVariationReferenceControls,
+    differences: {
+      wind: differences.filter((item) => item.path.includes("shear")),
+      moisture: differences.filter((item) => item.path.includes("moisture")),
+      "stability/thermodynamics": differences.filter((item) => item.path.includes("inversion")),
+      "forcing/initiation": differences.filter(
+        (item) =>
+          !item.path.includes("moisture") &&
+          !item.path.includes("inversion") &&
+          !item.path.includes("shear"),
+      ),
+      "numerical realization": profileChanged
+        ? [
+            {
+              path: "run_profile_id",
+              label: "Run profile",
+              before: "Presentation",
+              after: request.run_profile_id.includes("standard") ? "Standard" : "Extended",
+              units: null,
+              material: true,
+            },
+          ]
+        : [],
+      "observation plan": [],
+    },
+    relationship_classification:
+      physical.length && profileChanged
+        ? "mixed_variation"
+        : physical.length > 1
+          ? "multi_factor_physical_variation"
+          : physical.length === 1
+            ? "controlled_physical_variation"
+            : profileChanged
+              ? "numerical_sensitivity"
+              : null,
+    warnings:
+      request.controls.surface_sensible_heat_flux_k_m_s < 0
+        ? ["Surface sensible heat flux is downward."]
+        : [],
+    blocking_errors: impossible ? ["The requested inversion does not fit the model top."] : [],
+    diagnostics: {
+      inversion_top_m_agl:
+        request.controls.inversion_base_m_agl + request.controls.inversion_thickness_m,
+      model_top_m: 3_000,
+      sub_inversion_total_water_g_kg: request.controls.sub_inversion_total_water_g_kg,
+      free_tropospheric_rh_percent: request.controls.free_tropospheric_rh_percent,
+      cloud_layer_shear_m_s: request.controls.cloud_layer_shear_m_s,
+      cloud_layer_shear_direction_deg: request.controls.cloud_layer_shear_direction_deg,
+      cloud_layer_mean_u_m_s: request.controls.cloud_layer_mean_u_m_s,
+      cloud_layer_mean_v_m_s: request.controls.cloud_layer_mean_v_m_s,
+      initial_saturated_level_count: 0,
+      minimum_theta_gradient_k_km: 0,
+      labels: ["Large-scale subsidence"],
+    },
+    sounding_profile: [
+      {
+        height_m: 0,
+        theta_l_k: 298.7,
+        total_water_g_kg: request.controls.sub_inversion_total_water_g_kg,
+        relative_humidity_percent: 70,
+        u_m_s: -9,
+        v_m_s: 0,
+      },
+      {
+        height_m: 3_000,
+        theta_l_k: 311,
+        total_water_g_kg: 3,
+        relative_humidity_percent: request.controls.free_tropospheric_rh_percent,
+        u_m_s: -5,
+        v_m_s: 0,
+      },
+    ],
+    forcing_profile: [
+      {
+        height_m: 0,
+        vertical_motion_m_s: request.controls.large_scale_vertical_motion_m_s,
+        temperature_tendency_k_day: request.controls.temperature_tendency_k_day,
+        total_water_tendency_g_kg_day: request.controls.total_water_tendency_g_kg_day,
+      },
+      {
+        height_m: 3_000,
+        vertical_motion_m_s: 0,
+        temperature_tendency_k_day: 0,
+        total_water_tendency_g_kg_day: 0,
+      },
+    ],
+    numerical_realization: cost.profile.numerical_realization,
+    observation_plan: cost.profile.observation_plan,
+    cost_estimate: cost,
+  };
+}
+
+async function mockTradeCumulusVariationPath(
+  page: Parameters<typeof mockCloudChamberApis>[0],
+  options: { failPackage?: boolean } = {},
+) {
+  await mockTradeCumulusWorld(page);
+  let completed = false;
+  const variation = {
+    ...worldBaselineSimulation,
+    simulation_id: "trade_cumulus_direct_moisture_abcd1234",
+    display_name: "Direct Moisture Target",
+    role: "variation",
+    result_id: "result-trade-direct-moisture",
+    run_id: "trade-direct-moisture-run",
+    parent_simulation_id: worldBaselineSimulation.simulation_id,
+    recipe_contract_version: "1",
+    relationship_classification: "controlled_physical_variation",
+    can_create_variation: true,
+    parent_eligibility_reason: null,
+    attempt_count: 1,
+    compare_suggestions: [
+      {
+        comparison_id: "trade_cumulus_direct_moisture_parent",
+        display_name: "Direct Moisture Target versus Canonical BOMEX Baseline",
+        target_simulation_id: worldBaselineSimulation.simulation_id,
+      },
+    ],
+    configuration_difference_from_reference: [
+      {
+        path: "scientific_design.controls.surface_moisture_flux_g_kg_m_s",
+        label: "Surface moisture flux",
+        category: "atmospheric",
+        left_value: 0.052,
+        right_value: 0.09,
+        units: "g/kg m/s",
+        material: true,
+      },
+    ],
+  };
+  await page.unroute("**/api/worlds/trade-cumulus");
+  await page.route("**/api/worlds/trade-cumulus", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...tradeCumulusWorld,
+        reference_simulation: { ...worldBaselineSimulation, can_create_variation: true },
+        simulations: [
+          { ...worldBaselineSimulation, can_create_variation: true },
+          { ...worldMoreMoistureSimulation, can_create_variation: true },
+          ...(completed ? [variation] : []),
+        ],
+      }),
+    }),
+  );
+  await page.unroute("**/api/worlds/trade-cumulus/compare**");
+  await page.route("**/api/worlds/trade-cumulus/compare**", (route) => {
+    const search = new URL(route.request().url()).searchParams;
+    const leftId = search.get("left_simulation_id") ?? worldBaselineSimulation.simulation_id;
+    const rightId = search.get("right_simulation_id") ?? variation.simulation_id;
+    const descriptors = [
+      compareTradeSimulation(worldBaselineSimulation, comparisonStory.baseline),
+      {
+        ...compareTradeSimulation(worldBaselineSimulation, comparisonStory.baseline),
+        simulation_id: variation.simulation_id,
+        display_name: variation.display_name,
+        role: "variation",
+        run_id: variation.run_id,
+        result_id: variation.result_id,
+        parent_simulation_id: worldBaselineSimulation.simulation_id,
+        lineage_state: "valid",
+      },
+    ];
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...tradeCumulusCompareDescriptor,
+        simulations: descriptors,
+        default_left_simulation_id: worldBaselineSimulation.simulation_id,
+        default_right_simulation_id: variation.simulation_id,
+        selected_left_simulation_id: leftId,
+        selected_right_simulation_id: rightId,
+        material_differences: variation.configuration_difference_from_reference,
+        compatibility: {
+          ...tradeCumulusCompareDescriptor.compatibility,
+          relationship:
+            "Direct Moisture Target is a controlled physical variation of Canonical BOMEX Baseline.",
+          controlled_pair_message:
+            "One material physical control changed while numerical and observation layers remain matched.",
+        },
+      }),
+    });
+  });
+  await page.route("**/api/worlds/trade-cumulus/variation-template**", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(
+        tradeVariationTemplate(
+          new URL(route.request().url()).searchParams.get("parent_simulation_id") ===
+            variation.simulation_id
+            ? variation
+            : worldBaselineSimulation,
+        ),
+      ),
+    }),
+  );
+  await page.route("**/api/worlds/trade-cumulus/variations/preview", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(tradeVariationPreview(route.request().postDataJSON())),
+    }),
+  );
+  await page.route("**/api/worlds/trade-cumulus/variations", (route) =>
+    route.fulfill({
+      status: options.failPackage ? 400 : 200,
+      contentType: "application/json",
+      body: JSON.stringify(
+        options.failPackage
+          ? { detail: "Variation package preflight failed." }
+          : {
+              simulation_id: variation.simulation_id,
+              run_id: variation.run_id,
+              manifest_path: "/mock/trade-direct-moisture/run_manifest.json",
+              package_dir: "/mock/trade-direct-moisture",
+              launch_review_snapshot_id: "trade-launch-review",
+              warnings: [],
+            },
+      ),
+    }),
+  );
+  await page.unroute("**/api/runs/queue");
+  await page.route("**/api/runs/queue", (route) => {
+    if (route.request().method() === "POST") completed = true;
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        entries: [],
+        active_run_id: null,
+        queued_count: 0,
+        updated_at: "2026-07-28T18:00:00Z",
+      }),
+    });
+  });
+  await page.unroute("**/api/lifecycle");
+  await page.route("**/api/lifecycle", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        schema_version: "1",
+        generated_at: "2026-07-28T18:00:00Z",
+        records: completed
+          ? [
+              {
+                record_id: `simulation:trade_cumulus:${variation.simulation_id}`,
+                record_kind: "simulation",
+                owner_id: "trade_cumulus",
+                owner_label: "Trade Cumulus",
+                simulation_id: variation.simulation_id,
+                experiment_id: null,
+                world_id: "trade_cumulus",
+                recipe_id: "canonical_bomex_trade_cumulus",
+                recipe_version: "1",
+                parent_simulation_id: worldBaselineSimulation.simulation_id,
+                reference_simulation_id: worldBaselineSimulation.simulation_id,
+                display_name: variation.display_name,
+                question: "How does a direct moisture target change the cloud field?",
+                role: "variation",
+                case_id: "trade_cumulus_recipe_variation_v1",
+                differences: variation.configuration_difference_from_reference,
+                attempts: [
+                  {
+                    attempt_id: variation.run_id,
+                    run_id: variation.run_id,
+                    relationship: "initial",
+                    accepted_backing: true,
+                    manifest_path: "/mock/trade-direct-moisture/run_manifest.json",
+                    lifecycle_state: "completed",
+                    queue_state: null,
+                    product_state: "completed_cm1_result",
+                    validation_status: "valid",
+                    result_id: variation.result_id,
+                    output_artifact_count: 121,
+                    size_bytes: 2 * 1024 ** 3,
+                    retained_state: "retained",
+                    created_at: "2026-07-28T17:00:00Z",
+                    started_at: "2026-07-28T17:01:00Z",
+                    finished_at: "2026-07-28T17:25:00Z",
+                    updated_at: "2026-07-28T17:25:00Z",
+                    message: null,
+                    failure_reason: null,
+                  },
+                ],
+                facts: {
+                  scientific_work: "present",
+                  package: "present",
+                  attempt: "present",
+                  queue: "not_applicable",
+                  process: "passed",
+                  expected_output: "present",
+                  technical_integrity: "passed",
+                  ingest: "present",
+                  world_inspectability: "passed",
+                  simulation_availability: "present",
+                  parent_eligibility: "eligible",
+                  retained_assets: "present",
+                },
+                trust_state: "trusted",
+                caveats: [],
+                tags: ["controlled physical variation"],
+                notes: null,
+                lifecycle_label: "Available",
+                lifecycle_detail: "The Simulation is inspectable in Trade Cumulus.",
+                activity_group: "recently_completed",
+                in_activity: true,
+                created_at: "2026-07-28T17:00:00Z",
+                updated_at: "2026-07-28T17:25:00Z",
+                size_bytes: 2 * 1024 ** 3,
+                dependencies: [],
+                actions: [
+                  {
+                    kind: "explore",
+                    label: "Explore",
+                    world_id: "trade_cumulus",
+                    simulation_id: variation.simulation_id,
+                    result_id: variation.result_id,
+                  },
+                ],
+              },
+            ]
+          : [],
+        warnings: [],
+      }),
+    }),
+  );
+}
+
 test.describe("mocked smoke: Build, Results, Explore path", () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
@@ -2294,5 +2759,90 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
     expect(focusedHeatmapBox?.height ?? 0).toBeGreaterThan(280);
     await page.getByRole("button", { name: "Restore slice viewer" }).click();
     await expect(notebook).toBeAttached();
+  });
+
+  test("Trade Cumulus direct-value variation reaches Activity, Explore, Compare, and reuse", async ({
+    page,
+  }) => {
+    await mockTradeCumulusVariationPath(page);
+    await gotoApp(page);
+    await page.getByRole("button", { name: "Enter Trade Cumulus" }).click();
+    await page
+      .getByRole("navigation", { name: "Trade Cumulus sections" })
+      .getByRole("button", { name: "Create Variation", exact: true })
+      .click();
+
+    await expect(page.getByRole("heading", { name: "Atmosphere and forcing" })).toBeVisible();
+    await expect(page.getByLabel("Moisture flux exact value")).toHaveValue("0.052");
+    await expect(page.getByText("0 material changes")).toBeVisible();
+
+    await page.getByLabel("Moisture flux exact value").fill("0.09");
+    await page.getByLabel("Sensible heat flux exact value").fill("0.012");
+    await expect(page.getByText("2 material changes")).toBeVisible();
+    await expect(page.getByText("Multi-factor physical variation")).toBeVisible();
+
+    await page.getByRole("radio", { name: /Standard/ }).check();
+    await expect(page.getByText("Mixed physical and numerical variation")).toBeVisible();
+    await page.getByLabel("Inversion base exact value").fill("4000");
+    await expect(page.getByRole("alert")).toContainText(
+      "requested inversion does not fit the model top",
+    );
+    await expect(page.getByRole("button", { name: "Package variation" })).toBeDisabled();
+
+    await page.getByRole("button", { name: "Restore parent" }).click();
+    await page.getByRole("radio", { name: /Extended/ }).check();
+    await expect(page.getByText("This profile is uncharacterized.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Package variation" })).toBeDisabled();
+
+    await page.getByRole("button", { name: "Restore parent" }).click();
+    await page.getByLabel("Variation name").fill("Direct Moisture Target");
+    await page.getByLabel("Moisture flux exact value").fill("0.09");
+    await expect(page.getByText("Controlled physical variation")).toBeVisible();
+    await page.getByRole("button", { name: "Package variation" }).click();
+    await expect(
+      page.getByText("Direct Moisture Target is packaged. It has not been queued."),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Queue CM1" }).click();
+
+    await expect(page.getByRole("heading", { name: "Current work" })).toBeVisible();
+    await expect(page.locator("article", { hasText: "Direct Moisture Target" })).toBeVisible();
+    await page.getByRole("button", { name: "Simulations" }).click();
+    const descendant = page.locator("article", { hasText: "Direct Moisture Target" });
+    await expect(descendant.getByRole("button", { name: "Explore" })).toBeEnabled();
+    await expect(descendant.getByRole("button", { name: "Compare" })).toBeEnabled();
+    await expect(descendant.getByRole("button", { name: "Create variation" })).toBeEnabled();
+
+    await descendant.getByRole("button", { name: "Compare" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Review the two Simulations before loading frames" }),
+    ).toBeVisible();
+    await expect(page.getByText("Controlled pair")).toBeVisible();
+    await expect(page.getByRole("cell", { name: "Surface moisture flux" })).toBeVisible();
+    await page.getByRole("button", { name: "Back to Trade Cumulus" }).click();
+
+    await page.getByRole("button", { name: "Simulations" }).click();
+    await page
+      .locator("article", { hasText: "Direct Moisture Target" })
+      .getByRole("button", { name: "Create variation" })
+      .click();
+    await expect(page.getByLabel("Parent Simulation")).toHaveValue(
+      "trade_cumulus_direct_moisture_abcd1234",
+    );
+  });
+
+  test("Trade Cumulus keeps a package failure inside Create Variation", async ({ page }) => {
+    await mockTradeCumulusVariationPath(page, { failPackage: true });
+    await gotoApp(page);
+    await page.getByRole("button", { name: "Enter Trade Cumulus" }).click();
+    await page
+      .getByRole("navigation", { name: "Trade Cumulus sections" })
+      .getByRole("button", { name: "Create Variation", exact: true })
+      .click();
+    await page.getByLabel("Variation name").fill("Rejected direct target");
+    await page.getByLabel("Moisture flux exact value").fill("0.09");
+    await page.getByRole("button", { name: "Package variation" }).click();
+
+    await expect(page.getByRole("alert")).toHaveText("Variation package preflight failed.");
+    await expect(page.getByRole("heading", { name: "Atmosphere and forcing" })).toBeVisible();
   });
 });

--- a/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
+++ b/app/frontend/e2e/mocked-smoke/build-results-explore.spec.ts
@@ -2783,7 +2783,7 @@ test.describe("mocked smoke: Build, Results, Explore path", () => {
 
     await page.getByRole("radio", { name: /Standard/ }).check();
     await expect(page.getByText("Mixed physical and numerical variation")).toBeVisible();
-    await page.getByLabel("Inversion base exact value").fill("4000");
+    await page.getByLabel("Inversion base exact value").fill("2800");
     await expect(page.getByRole("alert")).toContainText(
       "requested inversion does not fit the model top",
     );

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -239,6 +239,21 @@
   min-width: 0;
 }
 
+.variation-range-inputs {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 5.2rem;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.variation-range-inputs input[type="number"] {
+  box-sizing: border-box;
+  min-height: 2rem;
+  padding: 0.3rem 0.4rem;
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+}
+
 .variation-range-field small {
   color: var(--color-text-muted);
   font-size: 0.59rem;
@@ -276,6 +291,66 @@
 
 .variation-advanced[open] .variation-control-groups {
   margin-top: 0.7rem;
+}
+
+.variation-wind-summary {
+  display: grid;
+  gap: 0.18rem;
+  border-left: 3px solid var(--color-border-strong);
+  padding: 0.35rem 0.55rem;
+  background: var(--color-surface-muted);
+}
+
+.variation-wind-summary span {
+  color: var(--color-text-muted);
+  font-size: 0.6rem;
+}
+
+.variation-wind-summary strong {
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.variation-forcing-controls {
+  display: grid;
+  gap: 0.7rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.7rem;
+}
+
+.variation-forcing-controls > header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.variation-forcing-controls h5,
+.variation-forcing-controls p {
+  margin: 0;
+}
+
+.variation-forcing-controls h5 {
+  font-size: 0.72rem;
+}
+
+.variation-forcing-controls p {
+  margin-top: 0.12rem;
+  color: var(--color-text-muted);
+  font-size: 0.62rem;
+}
+
+.variation-convenience-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+
+.variation-convenience-actions button {
+  min-height: 2rem;
+  padding: 0.35rem 0.55rem;
+  font-size: 0.62rem;
 }
 
 .variation-scientific-preview {
@@ -410,6 +485,12 @@
   stroke-width: 1;
 }
 
+.variation-profile-plot .profile-marker {
+  stroke: var(--color-warning);
+  stroke-dasharray: 2 3;
+  stroke-width: 1;
+}
+
 .variation-profile-plot .profile-line {
   fill: none;
   stroke: var(--color-accent-primary);
@@ -449,6 +530,10 @@
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 0.45rem;
+}
+
+.trade-profile-options {
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
 }
 
 .variation-profile-option {
@@ -672,6 +757,62 @@
   text-align: right;
 }
 
+.variation-exact-review {
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.55rem;
+}
+
+.variation-exact-review summary {
+  font-size: 0.68rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.variation-exact-table {
+  display: grid;
+  gap: 0;
+  margin-top: 0.45rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.variation-exact-heading,
+.variation-exact-table > div:not(.variation-exact-heading) {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 1.7fr) repeat(4, minmax(3.2rem, 0.72fr));
+  column-gap: 0.25rem;
+  align-items: center;
+}
+
+.variation-exact-heading {
+  padding: 0.3rem 0.35rem;
+  background: var(--color-surface-muted);
+  color: var(--color-text-muted);
+  font-size: 0.51rem;
+  font-weight: 800;
+}
+
+.variation-exact-table > div:not(.variation-exact-heading) {
+  border-top: 1px solid var(--color-border);
+  padding: 0.34rem 0.35rem 0.26rem;
+  font-size: 0.55rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.variation-exact-table strong {
+  min-width: 0;
+  font-size: 0.55rem;
+  overflow-wrap: anywhere;
+}
+
+.variation-exact-table small {
+  grid-column: 1 / -1;
+  margin-top: 0.08rem;
+  color: var(--color-text-muted);
+  font-size: 0.49rem;
+}
+
 .variation-budget {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -745,6 +886,36 @@
   margin: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.58rem;
+}
+
+.variation-packaged-state small {
+  color: var(--color-text-muted);
+  font-size: 0.6rem;
+}
+
+.world-create-variation-callout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0.8rem 0;
+}
+
+.world-create-variation-callout h3,
+.world-create-variation-callout p {
+  margin: 0;
+}
+
+.world-create-variation-callout > div {
+  display: grid;
+  gap: 0.16rem;
+}
+
+.world-create-variation-callout > div > p:last-child {
+  color: var(--color-text-muted);
+  font-size: 0.72rem;
 }
 
 .mountain-waves-scientific-view {

--- a/app/frontend/src/App.css
+++ b/app/frontend/src/App.css
@@ -815,32 +815,71 @@
 
 .variation-budget {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.5rem;
   border-top: 1px solid var(--color-border);
   padding-top: 0.6rem;
 }
 
-.variation-budget > div {
-  display: grid;
-  gap: 0.1rem;
+.variation-budget h4 {
+  font-size: 0.7rem;
 }
 
+.variation-budget dl {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0;
+}
+
+.variation-budget dl > div {
+  display: grid;
+  gap: 0.1rem;
+  border-top: 1px solid var(--color-border);
+  padding: 0.35rem 0;
+}
+
+.variation-budget dl > div:nth-child(odd) {
+  padding-right: 0.5rem;
+}
+
+.variation-budget dt,
 .variation-budget span,
 .variation-budget p {
   color: var(--color-text-muted);
   font-size: 0.6rem;
 }
 
+.variation-budget dd,
 .variation-budget strong {
   font-size: 0.7rem;
 }
 
+.variation-budget dd {
+  margin: 0;
+  font-weight: 750;
+}
+
+.variation-retained-fields,
+.variation-evidence-basis {
+  display: grid;
+  gap: 0.18rem;
+  border-top: 1px solid var(--color-border);
+  padding-top: 0.45rem;
+}
+
+.variation-retained-fields span {
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
 .variation-budget p {
-  grid-column: 1 / -1;
   border-left: 3px solid var(--color-success);
   padding: 0.35rem 0.45rem;
   background: var(--color-success-soft);
+}
+
+.variation-budget p.variation-source-build-note {
+  border-left-color: var(--color-warning);
+  background: var(--color-warning-soft);
 }
 
 .variation-budget p.blocked {

--- a/app/frontend/src/TradeCumulusVariationEditor.test.tsx
+++ b/app/frontend/src/TradeCumulusVariationEditor.test.tsx
@@ -1,0 +1,454 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TradeCumulusVariationEditor } from "./TradeCumulusVariationEditor";
+import type { SimulationRecord, TradeCumulusWorldDetail } from "./TradeCumulusWorld";
+
+const referenceControls = {
+  surface_sensible_heat_flux_k_m_s: 0.008,
+  surface_moisture_flux_g_kg_m_s: 0.052,
+  sub_inversion_total_water_g_kg: 16.65,
+  inversion_base_m_agl: 520,
+  inversion_thickness_m: 960,
+  inversion_strength_k: 3.7,
+  free_tropospheric_rh_percent: 41,
+  cloud_layer_shear_m_s: 4.14,
+  cloud_layer_shear_direction_deg: 0,
+  cloud_layer_mean_u_m_s: -7.5,
+  cloud_layer_mean_v_m_s: 0,
+  large_scale_vertical_motion_m_s: -0.0065,
+  temperature_tendency_k_day: -2,
+  total_water_tendency_g_kg_day: -1.0368,
+};
+
+const baseline = simulation({
+  simulation_id: "trade_cumulus_canonical_bomex",
+  display_name: "Canonical BOMEX Baseline",
+  role: "reference",
+  run_id: "baseline-run",
+  result_id: "baseline-result",
+  can_create_variation: true,
+});
+
+const moreMoisture = simulation({
+  simulation_id: "trade_cumulus_more_moisture",
+  display_name: "More Moisture",
+  run_id: "more-run",
+  result_id: "more-result",
+  parent_simulation_id: baseline.simulation_id,
+  can_create_variation: true,
+});
+
+const world: TradeCumulusWorldDetail = {
+  world_id: "trade_cumulus",
+  display_name: "Trade Cumulus",
+  status: "mvp_candidate",
+  short_description: "Trade cumulus",
+  availability_state: "available",
+  availability_message: "Available",
+  reference_simulation: baseline,
+  simulations: [baseline, moreMoisture],
+  lab_history: [],
+  featured_comparison: {
+    comparison_id: "trade_cumulus_moisture_v1",
+    display_name: "More Moisture versus Baseline",
+    baseline_simulation_id: "trade_cumulus_canonical_bomex",
+    more_moisture_simulation_id: "trade_cumulus_more_moisture",
+    availability_state: "available",
+    availability_message: "Available",
+    open_available: true,
+  },
+  lab_summary: {
+    active_run_count: 0,
+    completed_uninspected_run_count: 0,
+    lab_history_count: 0,
+    summary: "Idle",
+  },
+  capabilities: {
+    reference_explore: true,
+    featured_comparison: true,
+    lab: true,
+    saved_views: false,
+    ordinary_compare: true,
+    saved_comparisons: true,
+  },
+  caveats: [],
+};
+
+describe("TradeCumulusVariationEditor", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+        if (url.includes("variation-template")) {
+          const more = url.includes("trade_cumulus_more_moisture");
+          return ok(template(more));
+        }
+        if (url.endsWith("/variations/preview")) {
+          const body = JSON.parse(String(init?.body));
+          return ok(preview(body));
+        }
+        if (url.endsWith("/variations")) {
+          return ok({
+            simulation_id: "trade_cumulus_direct_target_abcd1234",
+            run_id: "trade-variation-run",
+            manifest_path: "/runs/trade-variation-run/run_manifest.json",
+            package_dir: "/runs/trade-variation-run",
+            launch_review_snapshot_id: "launch-review-trade",
+            warnings: [],
+          });
+        }
+        if (url === "/api/runs/queue") return ok({ state: "queued" });
+        throw new Error(`Unexpected fetch ${url}`);
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows direct values, exact reference-parent-child review, and separate queueing", async () => {
+    const onCreated = vi.fn();
+    render(
+      <TradeCumulusVariationEditor
+        world={world}
+        initialParentSimulationId={baseline.simulation_id ?? ""}
+        onCreated={onCreated}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Atmosphere and forcing" }),
+    ).toBeInTheDocument();
+    const moistureInput = screen.getByLabelText("Moisture flux exact value");
+    expect(moistureInput).toHaveValue(0.052);
+    expect(moistureInput.closest("label")).toHaveTextContent("g kg⁻¹ m s⁻¹");
+    expect(screen.queryByText(/forcing strength/i)).not.toBeInTheDocument();
+    await screen.findByText("0 material changes");
+
+    fireEvent.change(screen.getByLabelText("Moisture flux exact value"), {
+      target: { value: "0.09" },
+    });
+    expect(await screen.findByText("1 material changes")).toBeInTheDocument();
+    const review = screen.getByLabelText("Variation review");
+    expect(within(review).getByText("Reference")).toBeInTheDocument();
+    expect(within(review).getByText("Parent")).toBeInTheDocument();
+    expect(within(review).getByText("Child")).toBeInTheDocument();
+    expect(within(review).getByText("Δ")).toBeInTheDocument();
+    expect(within(review).getByText("+0.038")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Variation name"), {
+      target: { value: "Direct moisture target" },
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Package variation" })).toBeEnabled(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Package variation" }));
+    expect(
+      await screen.findByText("Direct moisture target is packaged. It has not been queued."),
+    ).toBeInTheDocument();
+    expect(onCreated).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Queue CM1" }));
+    await waitFor(() => expect(onCreated).toHaveBeenCalledOnce());
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/runs/queue",
+      expect.objectContaining({
+        body: JSON.stringify({
+          manifest_path: "/runs/trade-variation-run/run_manifest.json",
+        }),
+      }),
+    );
+  });
+
+  it("applies forcing shortcuts visibly and exposes advanced direct controls", async () => {
+    render(
+      <TradeCumulusVariationEditor
+        world={world}
+        initialParentSimulationId={baseline.simulation_id ?? ""}
+        onCreated={vi.fn()}
+      />,
+    );
+    await screen.findByText("0 material changes");
+    fireEvent.click(screen.getByText("Advanced profile structure"));
+    expect(screen.getByLabelText("Inversion thickness exact value")).toHaveValue(960);
+    expect(screen.getByLabelText("Shear direction exact value")).toHaveValue(0);
+    expect(screen.getByText("u -7.5 · v 0.0 m s⁻¹")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Layer-mean u wind exact value")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Zero forcing" }));
+    expect(screen.getByLabelText("Peak vertical motion exact value")).toHaveValue(0);
+    expect(screen.getByLabelText("Temperature tendency exact value")).toHaveValue(0);
+    expect(screen.getByLabelText("Total-water tendency exact value")).toHaveValue(0);
+    expect(await screen.findByText("3 material changes")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Restore reference forcing" }));
+    expect(screen.getByLabelText("Peak vertical motion exact value")).toHaveValue(-0.0065);
+    expect(await screen.findByText("0 material changes")).toBeInTheDocument();
+  });
+
+  it("switches parents without compounding the canonical Recipe transform", async () => {
+    render(
+      <TradeCumulusVariationEditor
+        world={world}
+        initialParentSimulationId={baseline.simulation_id ?? ""}
+        onCreated={vi.fn()}
+      />,
+    );
+    const parent = await screen.findByLabelText("Parent Simulation");
+    fireEvent.change(parent, { target: { value: "trade_cumulus_more_moisture" } });
+
+    const moistureInput = await screen.findByLabelText("Moisture flux exact value");
+    expect(moistureInput).toHaveValue(0.078);
+    expect(moistureInput.closest("label")).toHaveTextContent("Ref 0.052");
+    expect(moistureInput.closest("label")).toHaveTextContent("Parent 0.078");
+  });
+
+  it("keeps unusual science launchable and blocks an impossible generated profile", async () => {
+    render(
+      <TradeCumulusVariationEditor
+        world={world}
+        initialParentSimulationId={baseline.simulation_id ?? ""}
+        onCreated={vi.fn()}
+      />,
+    );
+    await screen.findByText("0 material changes");
+    fireEvent.change(screen.getByLabelText("Sensible heat flux exact value"), {
+      target: { value: "-0.01" },
+    });
+    expect(await screen.findByText("Surface sensible heat flux is downward.")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Variation name"), {
+      target: { value: "Surface cooling" },
+    });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Package variation" })).toBeEnabled(),
+    );
+
+    fireEvent.change(screen.getByLabelText("Inversion base exact value"), {
+      target: { value: "4000" },
+    });
+    expect(await screen.findByText(/requested inversion does not fit/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Unavailable").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByRole("button", { name: "Package variation" })).toBeDisabled();
+  });
+});
+
+function template(more: boolean) {
+  const controls = {
+    ...referenceControls,
+    surface_moisture_flux_g_kg_m_s: more ? 0.078 : 0.052,
+  };
+  return {
+    parent_simulation_id: more ? "trade_cumulus_more_moisture" : "trade_cumulus_canonical_bomex",
+    parent_run_id: more ? "more-run" : "baseline-run",
+    parent_display_name: more ? "More Moisture" : "Canonical BOMEX Baseline",
+    parent_configuration_source: "Retained source-backed BOMEX atmosphere and forcing",
+    reference_simulation_id: "trade_cumulus_canonical_bomex",
+    recipe_id: "canonical_bomex_trade_cumulus",
+    recipe_name: "Canonical BOMEX Trade Cumulus",
+    recipe_contract_version: "1",
+    controls,
+    canonical_reference_controls: referenceControls,
+    run_profiles: [
+      cost("quick", "Quick", 10_800, 180, 61),
+      cost("standard", "Standard", 14_400, 120, 121),
+      cost("full-cycle", "Full-cycle", 21_600, 120, 181),
+      cost("presentation", "Presentation", 14_400, 60, 241),
+      cost("extended", "Extended", 14_400, 120, 121, true),
+    ],
+    default_run_profile_id: "presentation",
+    can_create_variation: true,
+    unavailable_reason: null,
+  };
+}
+
+function cost(
+  profileId: string,
+  role: string,
+  duration: number,
+  cadence: number,
+  histories: number,
+  blocked = false,
+) {
+  return {
+    profile: {
+      profile_id: profileId,
+      profile_name: `${role} — Trade Cumulus`,
+      role,
+      numerical_realization: {
+        domain: "6.4 km × 6.4 km × 3 km",
+        grid: "64 × 64 × 75",
+        spacing: "100 × 100 × 40 m",
+        timestep_strategy: "target 3 s",
+        physics_source: "Canonical BOMEX",
+      },
+      observation_plan: {
+        duration_seconds: duration,
+        output_cadence_seconds: cadence,
+        expected_history_count: histories,
+        retained_field_inventory: ["ql", "qv", "th", "prs", "u", "v", "w"],
+      },
+      expected_runtime_min_seconds: blocked ? null : 600,
+      expected_runtime_max_seconds: blocked ? null : 1_200,
+      expected_size_min_bytes: blocked ? null : 1024 ** 3,
+      expected_size_max_bytes: blocked ? null : 2 * 1024 ** 3,
+      estimate_basis: blocked ? "uncharacterized" : "scaled_from_measured",
+      confidence: blocked ? "Requires characterization" : "Existing evidence",
+      scientific_limitations: [],
+    },
+    current_free_space_bytes: 100 * 1024 ** 3,
+    projected_free_space_bytes: blocked ? null : 98 * 1024 ** 3,
+    required_free_space_bytes: blocked ? null : 4 * 1024 ** 3,
+    disposition: blocked ? "blocked" : "passes",
+    disposition_reason: blocked ? "Requires characterization" : "Passes",
+  };
+}
+
+function preview(body: {
+  controls: typeof referenceControls;
+  parent_simulation_id: string;
+  run_profile_id: string;
+}) {
+  const parent = {
+    ...referenceControls,
+    surface_moisture_flux_g_kg_m_s:
+      body.parent_simulation_id === "trade_cumulus_more_moisture" ? 0.078 : 0.052,
+  };
+  const changed = Object.entries(body.controls).filter(
+    ([key, value]) => value !== parent[key as keyof typeof parent],
+  );
+  const impossible = body.controls.inversion_base_m_agl === 4000;
+  const differences = changed.map(([key, value]) => ({
+    path: `controls.${key}`,
+    label:
+      key === "surface_moisture_flux_g_kg_m_s"
+        ? "Surface moisture flux"
+        : key === "surface_sensible_heat_flux_k_m_s"
+          ? "Surface sensible heat flux"
+          : key.replaceAll("_", " "),
+    before: parent[key as keyof typeof parent],
+    after: value,
+    units: null,
+    material: true,
+  }));
+  return {
+    requested_controls: body.controls,
+    resolved_controls: impossible
+      ? { ...body.controls, free_tropospheric_rh_percent: null }
+      : body.controls,
+    canonical_reference_controls: referenceControls,
+    parent_controls: parent,
+    differences: {
+      wind: [],
+      moisture: differences.filter((item) => item.path.includes("moisture_flux")),
+      "stability/thermodynamics": differences.filter((item) =>
+        item.path.includes("inversion_base"),
+      ),
+      "forcing/initiation": differences.filter(
+        (item) => !item.path.includes("moisture_flux") && !item.path.includes("inversion_base"),
+      ),
+      "numerical realization": [],
+      "observation plan": [],
+    },
+    relationship_classification:
+      changed.length === 1
+        ? "controlled_physical_variation"
+        : changed.length
+          ? "multi_factor_physical_variation"
+          : null,
+    warnings:
+      body.controls.surface_sensible_heat_flux_k_m_s < 0
+        ? ["Surface sensible heat flux is downward."]
+        : [],
+    blocking_errors: impossible ? ["The requested inversion does not fit the model top."] : [],
+    diagnostics: {
+      inversion_top_m_agl: body.controls.inversion_base_m_agl + 960,
+      model_top_m: 3_000,
+      sub_inversion_total_water_g_kg: body.controls.sub_inversion_total_water_g_kg,
+      free_tropospheric_rh_percent: impossible ? null : body.controls.free_tropospheric_rh_percent,
+      cloud_layer_shear_m_s: body.controls.cloud_layer_shear_m_s,
+      cloud_layer_shear_direction_deg: body.controls.cloud_layer_shear_direction_deg,
+      cloud_layer_mean_u_m_s: body.controls.cloud_layer_mean_u_m_s,
+      cloud_layer_mean_v_m_s: body.controls.cloud_layer_mean_v_m_s,
+      initial_saturated_level_count: 0,
+      minimum_theta_gradient_k_km: 0,
+      labels: ["Large-scale subsidence"],
+    },
+    sounding_profile: profile(),
+    forcing_profile: profile().map((level) => ({
+      height_m: level.height_m,
+      vertical_motion_m_s: -0.005,
+      temperature_tendency_k_day: -2,
+      total_water_tendency_g_kg_day: -1,
+    })),
+    numerical_realization: {
+      domain: "6.4 km × 6.4 km × 3 km",
+      grid: "64 × 64 × 75",
+      spacing: "100 × 100 × 40 m",
+      timestep_strategy: "target 3 s",
+      physics_source: "Canonical BOMEX",
+    },
+    observation_plan: {
+      duration_seconds: 14_400,
+      output_cadence_seconds: 60,
+      expected_history_count: 241,
+      retained_field_inventory: ["ql", "qv", "th", "prs", "u", "v", "w"],
+    },
+    cost_estimate: cost(body.run_profile_id, "Presentation", 14_400, 60, 241),
+  };
+}
+
+function profile() {
+  return [
+    {
+      height_m: 0,
+      theta_l_k: 298.7,
+      total_water_g_kg: 17,
+      relative_humidity_percent: 60,
+      u_m_s: -9,
+      v_m_s: 0,
+    },
+    {
+      height_m: 3_000,
+      theta_l_k: 311,
+      total_water_g_kg: 3,
+      relative_humidity_percent: 41,
+      u_m_s: -5,
+      v_m_s: 0,
+    },
+  ];
+}
+
+function simulation(overrides: Partial<SimulationRecord>): SimulationRecord {
+  return {
+    simulation_id: "simulation",
+    display_name: "Simulation",
+    role: "variation",
+    world_id: "trade_cumulus",
+    product_slice_id: "trade_cumulus_v1",
+    case_id: "bomex_trade_cumulus_baseline_v0",
+    result_id: "result",
+    run_id: "run",
+    source_recipe_id: "canonical_bomex_trade_cumulus",
+    parent_simulation_id: null,
+    reference_simulation_id: "trade_cumulus_canonical_bomex",
+    technical_state: "available",
+    technical_state_message: "Available",
+    technical_trust_state: "trusted",
+    explore_available: true,
+    compare_suggestions: [],
+    configuration_difference_from_reference: [],
+    lineage_state: "valid",
+    can_create_variation: false,
+    created_at: null,
+    completed_at: null,
+    ...overrides,
+  };
+}
+
+function ok(payload: unknown): Response {
+  return { ok: true, json: async () => payload } as Response;
+}

--- a/app/frontend/src/TradeCumulusVariationEditor.test.tsx
+++ b/app/frontend/src/TradeCumulusVariationEditor.test.tsx
@@ -243,7 +243,7 @@ describe("TradeCumulusVariationEditor", () => {
     );
 
     fireEvent.change(screen.getByLabelText("Inversion base exact value"), {
-      target: { value: "4000" },
+      target: { value: "2800" },
     });
     expect(await screen.findByText(/requested inversion does not fit/i)).toBeInTheDocument();
     expect(screen.getAllByText("Unavailable").length).toBeGreaterThanOrEqual(2);
@@ -360,7 +360,8 @@ function preview(body: {
   const changed = Object.entries(body.controls).filter(
     ([key, value]) => value !== parent[key as keyof typeof parent],
   );
-  const impossible = body.controls.inversion_base_m_agl === 4000;
+  const impossible =
+    body.controls.inversion_base_m_agl + body.controls.inversion_thickness_m >= 3000;
   const differences = changed.map(([key, value]) => ({
     path: `controls.${key}`,
     label:

--- a/app/frontend/src/TradeCumulusVariationEditor.test.tsx
+++ b/app/frontend/src/TradeCumulusVariationEditor.test.tsx
@@ -138,6 +138,18 @@ describe("TradeCumulusVariationEditor", () => {
     expect(within(review).getByText("Child")).toBeInTheDocument();
     expect(within(review).getByText("Δ")).toBeInTheDocument();
     expect(within(review).getByText("+0.038")).toBeInTheDocument();
+    const launchFacts = within(review).getByLabelText("Launch facts");
+    expect(within(launchFacts).getByText("Current free")).toBeInTheDocument();
+    expect(within(launchFacts).getByText("Required reserve")).toBeInTheDocument();
+    expect(within(launchFacts).getByText("Total required")).toBeInTheDocument();
+    expect(
+      within(launchFacts).getByText("96 × 96 × 100 · 6.40 km × 6.40 km × 3.00 km"),
+    ).toBeInTheDocument();
+    expect(within(launchFacts).getByText("target 2 s")).toBeInTheDocument();
+    expect(within(launchFacts).getByText("Every 1 min · 241 frames")).toBeInTheDocument();
+    expect(within(launchFacts).getByText("+0.089 K per g/kg")).toBeInTheDocument();
+    expect(within(launchFacts).getByText(/rho, u, v, w/)).toBeInTheDocument();
+    expect(within(launchFacts).getByText("Existing evidence")).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Variation name"), {
       target: { value: "Direct moisture target" },
@@ -183,6 +195,9 @@ describe("TradeCumulusVariationEditor", () => {
     expect(screen.getByLabelText("Temperature tendency exact value")).toHaveValue(0);
     expect(screen.getByLabelText("Total-water tendency exact value")).toHaveValue(0);
     expect(await screen.findByText("3 material changes")).toBeInTheDocument();
+    expect(
+      screen.getByText(/A second disk gate runs after the build and immediately before CM1 starts/),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Restore reference forcing" }));
     expect(screen.getByLabelText("Peak vertical motion exact value")).toHaveValue(-0.0065);
@@ -273,6 +288,14 @@ function cost(
   histories: number,
   blocked = false,
 ) {
+  const isPresentation = profileId === "presentation";
+  const isExtended = profileId === "extended";
+  const nx = isExtended ? 128 : isPresentation ? 96 : 64;
+  const ny = nx;
+  const nz = isPresentation ? 100 : 75;
+  const dx = isPresentation ? 6_400 / 96 : 100;
+  const dy = dx;
+  const dz = isPresentation ? 30 : 40;
   return {
     profile: {
       profile_id: profileId,
@@ -282,14 +305,30 @@ function cost(
         domain: "6.4 km × 6.4 km × 3 km",
         grid: "64 × 64 × 75",
         spacing: "100 × 100 × 40 m",
-        timestep_strategy: "target 3 s",
+        timestep_strategy: isPresentation ? "target 2 s" : "target 3 s",
         physics_source: "Canonical BOMEX",
+        exact_domain: {
+          nx,
+          ny,
+          nz,
+          dx_m: dx,
+          dy_m: dy,
+          dz_m: dz,
+          x_extent_m: nx * dx,
+          y_extent_m: ny * dy,
+          model_top_m: nz * dz,
+          x_min_m: (-nx * dx) / 2,
+          x_max_m: (nx * dx) / 2,
+          y_min_m: (-ny * dy) / 2,
+          y_max_m: (ny * dy) / 2,
+          timestep_seconds: isPresentation ? 2 : 3,
+        },
       },
       observation_plan: {
         duration_seconds: duration,
         output_cadence_seconds: cadence,
         expected_history_count: histories,
-        retained_field_inventory: ["ql", "qv", "th", "prs", "u", "v", "w"],
+        retained_field_inventory: ["ql", "qv", "th", "prs", "rho", "u", "v", "w", "hfx", "qfx"],
       },
       expected_runtime_min_seconds: blocked ? null : 600,
       expected_runtime_max_seconds: blocked ? null : 1_200,
@@ -297,7 +336,8 @@ function cost(
       expected_size_max_bytes: blocked ? null : 2 * 1024 ** 3,
       estimate_basis: blocked ? "uncharacterized" : "scaled_from_measured",
       confidence: blocked ? "Requires characterization" : "Existing evidence",
-      scientific_limitations: [],
+      scientific_limitations: ["Cloud response is an outcome, not an availability gate."],
+      required_post_run_reserve_bytes: 2 * 1024 ** 3,
     },
     current_free_space_bytes: 100 * 1024 ** 3,
     projected_free_space_bytes: blocked ? null : 98 * 1024 ** 3,
@@ -375,6 +415,11 @@ function preview(body: {
       cloud_layer_mean_v_m_s: body.controls.cloud_layer_mean_v_m_s,
       initial_saturated_level_count: 0,
       minimum_theta_gradient_k_km: 0,
+      surface_heat_to_moisture_ratio_k_per_g_kg:
+        body.controls.surface_moisture_flux_g_kg_m_s === 0
+          ? null
+          : body.controls.surface_sensible_heat_flux_k_m_s /
+            body.controls.surface_moisture_flux_g_kg_m_s,
       labels: ["Large-scale subsidence"],
     },
     sounding_profile: profile(),
@@ -388,16 +433,40 @@ function preview(body: {
       domain: "6.4 km × 6.4 km × 3 km",
       grid: "64 × 64 × 75",
       spacing: "100 × 100 × 40 m",
-      timestep_strategy: "target 3 s",
+      timestep_strategy: "target 2 s",
       physics_source: "Canonical BOMEX",
+      exact_domain: {
+        nx: 96,
+        ny: 96,
+        nz: 100,
+        dx_m: 6_400 / 96,
+        dy_m: 6_400 / 96,
+        dz_m: 30,
+        x_extent_m: 6_400,
+        y_extent_m: 6_400,
+        model_top_m: 3_000,
+        x_min_m: -3_200,
+        x_max_m: 3_200,
+        y_min_m: -3_200,
+        y_max_m: 3_200,
+        timestep_seconds: 2,
+      },
     },
     observation_plan: {
       duration_seconds: 14_400,
       output_cadence_seconds: 60,
       expected_history_count: 241,
-      retained_field_inventory: ["ql", "qv", "th", "prs", "u", "v", "w"],
+      retained_field_inventory: ["ql", "qv", "th", "prs", "rho", "u", "v", "w", "hfx", "qfx"],
     },
     cost_estimate: cost(body.run_profile_id, "Presentation", 14_400, 60, 241),
+    source_customization_required: [
+      "large_scale_vertical_motion_m_s",
+      "temperature_tendency_k_day",
+      "total_water_tendency_g_kg_day",
+    ].some(
+      (key) =>
+        body.controls[key as keyof typeof body.controls] !== parent[key as keyof typeof parent],
+    ),
   };
 }
 

--- a/app/frontend/src/TradeCumulusVariationEditor.tsx
+++ b/app/frontend/src/TradeCumulusVariationEditor.tsx
@@ -25,6 +25,22 @@ type NumericalRealization = {
   spacing: string;
   timestep_strategy: string;
   physics_source: string;
+  exact_domain: {
+    nx: number;
+    ny: number;
+    nz: number;
+    dx_m: number;
+    dy_m: number;
+    dz_m: number;
+    x_extent_m: number;
+    y_extent_m: number;
+    model_top_m: number;
+    x_min_m: number;
+    x_max_m: number;
+    y_min_m: number;
+    y_max_m: number;
+    timestep_seconds: number;
+  } | null;
 };
 
 type ObservationPlan = {
@@ -47,6 +63,7 @@ type RunCostProfile = {
   estimate_basis: "measured" | "scaled_from_measured" | "uncharacterized";
   confidence: string;
   scientific_limitations: string[];
+  required_post_run_reserve_bytes: number;
 };
 
 type RunCostEstimate = {
@@ -120,6 +137,7 @@ type VariationPreview = {
     cloud_layer_mean_v_m_s: number;
     initial_saturated_level_count: number;
     minimum_theta_gradient_k_km: number;
+    surface_heat_to_moisture_ratio_k_per_g_kg: number | null;
     labels: string[];
   };
   sounding_profile: ProfileLevel[];
@@ -127,6 +145,7 @@ type VariationPreview = {
   numerical_realization: NumericalRealization;
   observation_plan: ObservationPlan;
   cost_estimate: RunCostEstimate;
+  source_customization_required: boolean;
 };
 
 type VariationPackage = {
@@ -782,6 +801,9 @@ export function TradeCumulusVariationEditor({
                   <small>
                     {preview?.numerical_realization.spacing ??
                       selectedProfile.profile.numerical_realization.spacing}
+                    {" · "}
+                    {preview?.numerical_realization.timestep_strategy ??
+                      selectedProfile.profile.numerical_realization.timestep_strategy}
                   </small>
                 </div>
                 <div>
@@ -881,7 +903,7 @@ export function TradeCumulusVariationEditor({
 
               <DifferenceReview preview={preview} />
 
-              <CostReview estimate={preview.cost_estimate} />
+              <CostReview preview={preview} />
 
               {!packaged ? (
                 <button
@@ -1227,19 +1249,72 @@ function DifferenceReview({ preview }: { preview: VariationPreview }) {
   );
 }
 
-function CostReview({ estimate }: { estimate: RunCostEstimate }) {
+function CostReview({ preview }: { preview: VariationPreview }) {
+  const estimate = preview.cost_estimate;
+  const profile = estimate.profile;
+  const domain = preview.numerical_realization.exact_domain;
+  const observation = preview.observation_plan;
   return (
-    <section className="variation-budget">
+    <section className="variation-budget" aria-label="Launch facts">
+      <h4>Launch facts</h4>
       <dl>
         <div>
           <dt>Retained storage</dt>
-          <dd>{storageRange(estimate.profile)}</dd>
+          <dd>{storageRange(profile)}</dd>
+        </div>
+        <div>
+          <dt>Current free</dt>
+          <dd>{formatBytes(estimate.current_free_space_bytes)}</dd>
+        </div>
+        <div>
+          <dt>Required reserve</dt>
+          <dd>{formatBytes(profile.required_post_run_reserve_bytes)}</dd>
+        </div>
+        <div>
+          <dt>Total required</dt>
+          <dd>{formatBytes(estimate.required_free_space_bytes)}</dd>
         </div>
         <div>
           <dt>Free after high estimate</dt>
           <dd>{formatBytes(estimate.projected_free_space_bytes)}</dd>
         </div>
+        <div>
+          <dt>Domain and grid</dt>
+          <dd>{domain ? exactDomain(domain) : preview.numerical_realization.grid}</dd>
+        </div>
+        <div>
+          <dt>Timestep</dt>
+          <dd>{preview.numerical_realization.timestep_strategy}</dd>
+        </div>
+        <div>
+          <dt>Saved output</dt>
+          <dd>
+            Every {formatCadence(observation.output_cadence_seconds)} ·{" "}
+            {observation.expected_history_count ?? "Generated"} frames
+          </dd>
+        </div>
+        <div>
+          <dt>Surface exchange</dt>
+          <dd>{surfaceExchangeBalance(preview)}</dd>
+        </div>
       </dl>
+      <div className="variation-retained-fields">
+        <strong>Retained fields</strong>
+        <span>{observation.retained_field_inventory.join(", ")}</span>
+      </div>
+      <div className="variation-evidence-basis">
+        <strong>Evidence</strong>
+        <span>{profile.confidence}</span>
+        {profile.scientific_limitations.map((limitation) => (
+          <span key={limitation}>{limitation}</span>
+        ))}
+      </div>
+      {preview.source_customization_required && (
+        <p className="variation-source-build-note">
+          This forcing change stages an isolated CM1 source build. A second disk gate runs after the
+          build and immediately before CM1 starts.
+        </p>
+      )}
       <p className={estimate.disposition === "passes" ? "" : "blocked"}>
         {estimate.disposition_reason}
       </p>
@@ -1310,6 +1385,24 @@ function storageRange(profile: RunCostProfile): string {
   return `${formatBytes(profile.expected_size_min_bytes)}–${formatBytes(
     profile.expected_size_max_bytes,
   )}`;
+}
+
+function exactDomain(domain: NonNullable<NumericalRealization["exact_domain"]>): string {
+  return `${domain.nx} × ${domain.ny} × ${domain.nz} · ${formatDistance(
+    domain.x_extent_m,
+  )} × ${formatDistance(domain.y_extent_m)} × ${formatDistance(domain.model_top_m)}`;
+}
+
+function formatCadence(seconds: number | null): string {
+  if (seconds === null) return "generated cadence";
+  return seconds >= 60 && seconds % 60 === 0 ? `${seconds / 60} min` : `${seconds} s`;
+}
+
+function surfaceExchangeBalance(preview: VariationPreview): string {
+  const ratio = preview.diagnostics.surface_heat_to_moisture_ratio_k_per_g_kg;
+  return ratio === null
+    ? "Moisture flux is zero; ratio undefined"
+    : `${formatSigned(ratio, 3)} K per g/kg`;
 }
 
 function formatDuration(seconds: number | null): string {

--- a/app/frontend/src/TradeCumulusVariationEditor.tsx
+++ b/app/frontend/src/TradeCumulusVariationEditor.tsx
@@ -1,0 +1,1353 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+
+import type { TradeCumulusWorldDetail } from "./TradeCumulusWorld";
+
+type TradeCumulusControls = {
+  surface_sensible_heat_flux_k_m_s: number;
+  surface_moisture_flux_g_kg_m_s: number;
+  sub_inversion_total_water_g_kg: number;
+  inversion_base_m_agl: number;
+  inversion_thickness_m: number;
+  inversion_strength_k: number;
+  free_tropospheric_rh_percent: number;
+  cloud_layer_shear_m_s: number;
+  cloud_layer_shear_direction_deg: number;
+  cloud_layer_mean_u_m_s: number;
+  cloud_layer_mean_v_m_s: number;
+  large_scale_vertical_motion_m_s: number;
+  temperature_tendency_k_day: number;
+  total_water_tendency_g_kg_day: number;
+};
+
+type NumericalRealization = {
+  domain: string;
+  grid: string;
+  spacing: string;
+  timestep_strategy: string;
+  physics_source: string;
+};
+
+type ObservationPlan = {
+  duration_seconds: number | null;
+  output_cadence_seconds: number | null;
+  expected_history_count: number | null;
+  retained_field_inventory: string[];
+};
+
+type RunCostProfile = {
+  profile_id: string;
+  profile_name: string;
+  role: string;
+  numerical_realization: NumericalRealization;
+  observation_plan: ObservationPlan;
+  expected_runtime_min_seconds: number | null;
+  expected_runtime_max_seconds: number | null;
+  expected_size_min_bytes: number | null;
+  expected_size_max_bytes: number | null;
+  estimate_basis: "measured" | "scaled_from_measured" | "uncharacterized";
+  confidence: string;
+  scientific_limitations: string[];
+};
+
+type RunCostEstimate = {
+  profile: RunCostProfile;
+  current_free_space_bytes: number;
+  projected_free_space_bytes: number | null;
+  required_free_space_bytes: number | null;
+  disposition: "passes" | "blocked";
+  disposition_reason: string;
+};
+
+type VariationTemplate = {
+  parent_simulation_id: string;
+  parent_run_id: string;
+  parent_display_name: string;
+  parent_configuration_source: string;
+  reference_simulation_id: string;
+  recipe_id: "canonical_bomex_trade_cumulus";
+  recipe_name: string;
+  recipe_contract_version: string;
+  controls: TradeCumulusControls;
+  canonical_reference_controls: TradeCumulusControls;
+  run_profiles: RunCostEstimate[];
+  default_run_profile_id: string;
+  can_create_variation: boolean;
+  unavailable_reason: string | null;
+};
+
+type Difference = {
+  path: string;
+  label: string;
+  before: unknown;
+  after: unknown;
+  units: string | null;
+  material: boolean;
+};
+
+type ProfileLevel = {
+  height_m: number;
+  theta_l_k: number;
+  total_water_g_kg: number;
+  relative_humidity_percent: number;
+  u_m_s: number;
+  v_m_s: number;
+};
+
+type ForcingLevel = {
+  height_m: number;
+  vertical_motion_m_s: number;
+  temperature_tendency_k_day: number;
+  total_water_tendency_g_kg_day: number;
+};
+
+type VariationPreview = {
+  requested_controls: TradeCumulusControls;
+  resolved_controls: Record<ControlKey, number | null>;
+  canonical_reference_controls: TradeCumulusControls;
+  parent_controls: TradeCumulusControls;
+  differences: Record<string, Difference[]>;
+  relationship_classification: string | null;
+  warnings: string[];
+  blocking_errors: string[];
+  diagnostics: {
+    inversion_top_m_agl: number;
+    model_top_m: number;
+    sub_inversion_total_water_g_kg: number;
+    free_tropospheric_rh_percent: number | null;
+    cloud_layer_shear_m_s: number;
+    cloud_layer_shear_direction_deg: number;
+    cloud_layer_mean_u_m_s: number;
+    cloud_layer_mean_v_m_s: number;
+    initial_saturated_level_count: number;
+    minimum_theta_gradient_k_km: number;
+    labels: string[];
+  };
+  sounding_profile: ProfileLevel[];
+  forcing_profile: ForcingLevel[];
+  numerical_realization: NumericalRealization;
+  observation_plan: ObservationPlan;
+  cost_estimate: RunCostEstimate;
+};
+
+type VariationPackage = {
+  simulation_id: string;
+  run_id: string;
+  manifest_path: string;
+  package_dir: string;
+  launch_review_snapshot_id: string;
+  warnings: string[];
+};
+
+type ControlKey = keyof TradeCumulusControls;
+
+const CONTROL_META: Record<
+  ControlKey,
+  { label: string; units: string; min: number; max: number; step: number; digits: number }
+> = {
+  surface_sensible_heat_flux_k_m_s: {
+    label: "Sensible heat flux",
+    units: "K m s⁻¹",
+    min: -0.02,
+    max: 0.05,
+    step: 0.001,
+    digits: 3,
+  },
+  surface_moisture_flux_g_kg_m_s: {
+    label: "Moisture flux",
+    units: "g kg⁻¹ m s⁻¹",
+    min: -0.1,
+    max: 0.25,
+    step: 0.001,
+    digits: 3,
+  },
+  sub_inversion_total_water_g_kg: {
+    label: "Sub-inversion total water",
+    units: "g kg⁻¹",
+    min: 0,
+    max: 25,
+    step: 0.1,
+    digits: 1,
+  },
+  inversion_base_m_agl: {
+    label: "Inversion base",
+    units: "m AGL",
+    min: 300,
+    max: 4000,
+    step: 10,
+    digits: 0,
+  },
+  inversion_thickness_m: {
+    label: "Inversion thickness",
+    units: "m",
+    min: 50,
+    max: 2000,
+    step: 10,
+    digits: 0,
+  },
+  inversion_strength_k: {
+    label: "Inversion strength",
+    units: "K",
+    min: -5,
+    max: 20,
+    step: 0.1,
+    digits: 1,
+  },
+  free_tropospheric_rh_percent: {
+    label: "Free-tropospheric humidity",
+    units: "%",
+    min: 0,
+    max: 100,
+    step: 1,
+    digits: 0,
+  },
+  cloud_layer_shear_m_s: {
+    label: "0–3 km vector shear",
+    units: "m s⁻¹",
+    min: 0,
+    max: 50,
+    step: 0.1,
+    digits: 1,
+  },
+  cloud_layer_shear_direction_deg: {
+    label: "Shear direction",
+    units: "°",
+    min: 0,
+    max: 360,
+    step: 1,
+    digits: 0,
+  },
+  cloud_layer_mean_u_m_s: {
+    label: "Layer-mean u wind",
+    units: "m s⁻¹",
+    min: -50,
+    max: 50,
+    step: 0.5,
+    digits: 1,
+  },
+  cloud_layer_mean_v_m_s: {
+    label: "Layer-mean v wind",
+    units: "m s⁻¹",
+    min: -50,
+    max: 50,
+    step: 0.5,
+    digits: 1,
+  },
+  large_scale_vertical_motion_m_s: {
+    label: "Peak vertical motion",
+    units: "m s⁻¹",
+    min: -0.05,
+    max: 0.05,
+    step: 0.001,
+    digits: 3,
+  },
+  temperature_tendency_k_day: {
+    label: "Temperature tendency",
+    units: "K day⁻¹",
+    min: -20,
+    max: 10,
+    step: 0.1,
+    digits: 1,
+  },
+  total_water_tendency_g_kg_day: {
+    label: "Total-water tendency",
+    units: "g kg⁻¹ day⁻¹",
+    min: -20,
+    max: 10,
+    step: 0.1,
+    digits: 1,
+  },
+};
+
+const DIFFERENCE_GROUPS = [
+  "wind",
+  "moisture",
+  "stability/thermodynamics",
+  "forcing/initiation",
+  "numerical realization",
+  "observation plan",
+] as const;
+
+export function TradeCumulusVariationEditor({
+  world,
+  initialParentSimulationId,
+  onCreated,
+}: {
+  world: TradeCumulusWorldDetail;
+  initialParentSimulationId: string;
+  onCreated: () => Promise<void> | void;
+}) {
+  const eligibleParents = useMemo(
+    () => world.simulations.filter((simulation) => simulation.can_create_variation),
+    [world.simulations],
+  );
+  const [parentSimulationId, setParentSimulationId] = useState(initialParentSimulationId);
+  const [template, setTemplate] = useState<VariationTemplate | null>(null);
+  const [controls, setControls] = useState<TradeCumulusControls | null>(null);
+  const [runProfileId, setRunProfileId] = useState("");
+  const [simulationName, setSimulationName] = useState("");
+  const [userQuestion, setUserQuestion] = useState("");
+  const [preview, setPreview] = useState<VariationPreview | null>(null);
+  const [packaged, setPackaged] = useState<VariationPackage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [previewing, setPreviewing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [queueing, setQueueing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const previewSequence = useRef(0);
+
+  useEffect(() => setParentSimulationId(initialParentSimulationId), [initialParentSimulationId]);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    setStatus(null);
+    setPackaged(null);
+    void fetch(
+      `/api/worlds/trade-cumulus/variation-template?${new URLSearchParams({
+        parent_simulation_id: parentSimulationId,
+      })}`,
+    )
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(await responseMessage(response, "Unable to load the parent Simulation."));
+        }
+        return (await response.json()) as VariationTemplate;
+      })
+      .then((payload) => {
+        if (!active) return;
+        setTemplate(payload);
+        setControls({ ...payload.controls });
+        setRunProfileId(payload.default_run_profile_id);
+      })
+      .catch((caught) => {
+        if (!active) return;
+        setTemplate(null);
+        setControls(null);
+        setError(
+          caught instanceof Error ? caught.message : "Unable to load the parent Simulation.",
+        );
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [parentSimulationId]);
+
+  useEffect(() => {
+    if (!controls || !template?.can_create_variation || !runProfileId || packaged) {
+      if (!packaged) setPreview(null);
+      return;
+    }
+    const sequence = previewSequence.current + 1;
+    previewSequence.current = sequence;
+    const timer = window.setTimeout(() => {
+      setPreviewing(true);
+      void fetch("/api/worlds/trade-cumulus/variations/preview", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          requestPayload({
+            parentSimulationId,
+            simulationName: simulationName.trim() || "Untitled Trade Cumulus variation",
+            userQuestion,
+            runProfileId,
+            controls,
+          }),
+        ),
+      })
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error(await responseMessage(response, "Unable to preview this variation."));
+          }
+          return (await response.json()) as VariationPreview;
+        })
+        .then((payload) => {
+          if (sequence !== previewSequence.current) return;
+          setPreview(payload);
+          setError(null);
+        })
+        .catch((caught) => {
+          if (sequence !== previewSequence.current) return;
+          setPreview(null);
+          setError(caught instanceof Error ? caught.message : "Unable to preview this variation.");
+        })
+        .finally(() => {
+          if (sequence === previewSequence.current) setPreviewing(false);
+        });
+    }, 250);
+    return () => window.clearTimeout(timer);
+  }, [
+    controls,
+    packaged,
+    parentSimulationId,
+    runProfileId,
+    simulationName,
+    template,
+    userQuestion,
+  ]);
+
+  const selectedProfile = template?.run_profiles.find(
+    (estimate) => estimate.profile.profile_id === runProfileId,
+  );
+  const differenceCount = preview
+    ? Object.values(preview.differences).reduce((total, group) => total + group.length, 0)
+    : 0;
+  const canPackage =
+    Boolean(simulationName.trim()) &&
+    Boolean(preview) &&
+    preview?.blocking_errors.length === 0 &&
+    preview?.cost_estimate.disposition === "passes" &&
+    !submitting;
+
+  function updateControl(key: ControlKey, value: number) {
+    setControls((current) => (current ? { ...current, [key]: value } : current));
+  }
+
+  function restoreParent() {
+    if (!template) return;
+    setControls({ ...template.controls });
+    setRunProfileId(template.default_run_profile_id);
+    setPackaged(null);
+    setStatus("Parent Recipe controls restored.");
+  }
+
+  function restoreReferenceForcing() {
+    if (!template) return;
+    const reference = template.canonical_reference_controls;
+    setControls((current) =>
+      current
+        ? {
+            ...current,
+            large_scale_vertical_motion_m_s: reference.large_scale_vertical_motion_m_s,
+            temperature_tendency_k_day: reference.temperature_tendency_k_day,
+            total_water_tendency_g_kg_day: reference.total_water_tendency_g_kg_day,
+          }
+        : current,
+    );
+  }
+
+  function zeroForcing() {
+    setControls((current) =>
+      current
+        ? {
+            ...current,
+            large_scale_vertical_motion_m_s: 0,
+            temperature_tendency_k_day: 0,
+            total_water_tendency_g_kg_day: 0,
+          }
+        : current,
+    );
+  }
+
+  async function packageVariation() {
+    if (!controls || !simulationName.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    setStatus("Writing the exact package and launch review...");
+    try {
+      const response = await fetch("/api/worlds/trade-cumulus/variations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          requestPayload({
+            parentSimulationId,
+            simulationName: simulationName.trim(),
+            userQuestion,
+            runProfileId,
+            controls,
+          }),
+        ),
+      });
+      if (!response.ok) {
+        throw new Error(await responseMessage(response, "Unable to package this variation."));
+      }
+      const payload = (await response.json()) as VariationPackage;
+      setPackaged(payload);
+      setStatus(`${simulationName.trim()} is packaged. It has not been queued.`);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to package this variation.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function queuePackage() {
+    if (!packaged) return;
+    setQueueing(true);
+    setError(null);
+    setStatus("Running the immediate launch gate and joining the queue...");
+    try {
+      const response = await fetch("/api/runs/queue", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ manifest_path: packaged.manifest_path }),
+      });
+      if (!response.ok) {
+        throw new Error(
+          await responseMessage(
+            response,
+            "The package remains available, but it could not be queued.",
+          ),
+        );
+      }
+      setStatus(`${simulationName.trim()} is queued as ${packaged.run_id}.`);
+      await onCreated();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Unable to queue this package.");
+    } finally {
+      setQueueing(false);
+    }
+  }
+
+  if (loading) {
+    return <section className="lab-content status-panel">Loading Recipe controls...</section>;
+  }
+
+  if (!template || !controls) {
+    return (
+      <section className="lab-content world-load-failure">
+        <div>
+          <h3>Variation controls are unavailable</h3>
+          <p role="alert">{error}</p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      className="lab-content mountain-waves-variation-editor trade-cumulus-variation-editor"
+      aria-labelledby="trade-variation-title"
+    >
+      <header className="variation-editor-header">
+        <div>
+          <p className="eyebrow">Create Variation</p>
+          <h3 id="trade-variation-title">Design a related Trade Cumulus Simulation</h3>
+          <p>
+            Enter direct atmospheric and forcing targets, inspect the generated profile, then
+            package the exact experiment before deciding whether to queue CM1.
+          </p>
+        </div>
+        <button type="button" className="secondary-button" onClick={restoreParent}>
+          Restore parent
+        </button>
+      </header>
+
+      <div className="variation-editor-grid">
+        <div className="variation-editor-main">
+          <section className="variation-section variation-identity-section">
+            <SectionTitle
+              step="1"
+              title="Simulation identity"
+              detail="The Recipe follows the selected parent and cannot be silently changed."
+            />
+            <div className="variation-identity-grid">
+              <label>
+                Parent Simulation
+                <select
+                  value={parentSimulationId}
+                  disabled={Boolean(packaged)}
+                  onChange={(event) => setParentSimulationId(event.target.value)}
+                >
+                  {eligibleParents.map((parent) => (
+                    <option key={parent.simulation_id} value={parent.simulation_id ?? ""}>
+                      {parent.display_name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <div className="variation-recipe-identity">
+                <span>Recipe</span>
+                <strong>{template.recipe_name}</strong>
+                <small>Contract version {template.recipe_contract_version}</small>
+              </div>
+              <label>
+                Variation name
+                <input
+                  value={simulationName}
+                  placeholder="e.g. Weak inversion with ascent"
+                  maxLength={80}
+                  disabled={Boolean(packaged)}
+                  onChange={(event) => setSimulationName(event.target.value)}
+                />
+              </label>
+              <label>
+                Scientific question <span className="optional-label">optional</span>
+                <input
+                  value={userQuestion}
+                  placeholder="What are you trying to learn?"
+                  disabled={Boolean(packaged)}
+                  onChange={(event) => setUserQuestion(event.target.value)}
+                />
+              </label>
+            </div>
+            <p className="variation-parent-source">{template.parent_configuration_source}</p>
+          </section>
+
+          <section className="variation-section">
+            <SectionTitle
+              step="2"
+              title="Atmosphere and forcing"
+              detail="Values are absolute physical targets; the generated profile proves what CM1 will receive."
+            />
+            <div className="variation-control-groups three-up">
+              <ControlGroup title="Surface exchange">
+                <RangeField
+                  controlKey="surface_sensible_heat_flux_k_m_s"
+                  value={controls.surface_sensible_heat_flux_k_m_s}
+                  template={template}
+                  disabled={Boolean(packaged)}
+                  onChange={updateControl}
+                />
+                <RangeField
+                  controlKey="surface_moisture_flux_g_kg_m_s"
+                  value={controls.surface_moisture_flux_g_kg_m_s}
+                  template={template}
+                  disabled={Boolean(packaged)}
+                  onChange={updateControl}
+                />
+              </ControlGroup>
+              <ControlGroup title="Initial atmosphere">
+                <RangeField
+                  controlKey="sub_inversion_total_water_g_kg"
+                  value={controls.sub_inversion_total_water_g_kg}
+                  template={template}
+                  disabled={Boolean(packaged)}
+                  onChange={updateControl}
+                />
+                <RangeField
+                  controlKey="inversion_base_m_agl"
+                  value={controls.inversion_base_m_agl}
+                  template={template}
+                  disabled={Boolean(packaged)}
+                  onChange={updateControl}
+                />
+                <RangeField
+                  controlKey="inversion_strength_k"
+                  value={controls.inversion_strength_k}
+                  template={template}
+                  disabled={Boolean(packaged)}
+                  onChange={updateControl}
+                />
+                <RangeField
+                  controlKey="free_tropospheric_rh_percent"
+                  value={controls.free_tropospheric_rh_percent}
+                  template={template}
+                  disabled={Boolean(packaged)}
+                  onChange={updateControl}
+                />
+              </ControlGroup>
+              <ControlGroup title="Cloud-layer wind">
+                <RangeField
+                  controlKey="cloud_layer_shear_m_s"
+                  value={controls.cloud_layer_shear_m_s}
+                  template={template}
+                  disabled={Boolean(packaged)}
+                  onChange={updateControl}
+                />
+                <div className="variation-wind-summary">
+                  <span>0–3 km layer mean</span>
+                  <strong>
+                    u {formatNumber(controls.cloud_layer_mean_u_m_s, 1)} · v{" "}
+                    {formatNumber(controls.cloud_layer_mean_v_m_s, 1)} m s⁻¹
+                  </strong>
+                </div>
+              </ControlGroup>
+            </div>
+
+            <details className="variation-advanced">
+              <summary>Advanced profile structure</summary>
+              <div className="variation-control-groups">
+                <ControlGroup title="Inversion geometry">
+                  <RangeField
+                    controlKey="inversion_thickness_m"
+                    value={controls.inversion_thickness_m}
+                    template={template}
+                    disabled={Boolean(packaged)}
+                    onChange={updateControl}
+                  />
+                </ControlGroup>
+                <ControlGroup title="Shear vector">
+                  <RangeField
+                    controlKey="cloud_layer_shear_direction_deg"
+                    value={controls.cloud_layer_shear_direction_deg}
+                    template={template}
+                    disabled={Boolean(packaged) || controls.cloud_layer_shear_m_s === 0}
+                    onChange={updateControl}
+                  />
+                </ControlGroup>
+              </div>
+            </details>
+
+            <section className="variation-forcing-controls" aria-labelledby="forcing-title">
+              <header>
+                <div>
+                  <h5 id="forcing-title">Large-scale forcing</h5>
+                  <p>Signed peak targets retain the authored BOMEX vertical shapes.</p>
+                </div>
+                <div className="variation-convenience-actions">
+                  <button
+                    type="button"
+                    className="secondary-button"
+                    disabled={Boolean(packaged)}
+                    onClick={restoreReferenceForcing}
+                  >
+                    Restore reference forcing
+                  </button>
+                  <button
+                    type="button"
+                    className="secondary-button"
+                    disabled={Boolean(packaged)}
+                    onClick={zeroForcing}
+                  >
+                    Zero forcing
+                  </button>
+                </div>
+              </header>
+              <div className="variation-control-groups three-up">
+                {(
+                  [
+                    "large_scale_vertical_motion_m_s",
+                    "temperature_tendency_k_day",
+                    "total_water_tendency_g_kg_day",
+                  ] as ControlKey[]
+                ).map((key) => (
+                  <ControlGroup key={key} title={CONTROL_META[key].label}>
+                    <RangeField
+                      controlKey={key}
+                      value={controls[key]}
+                      template={template}
+                      disabled={Boolean(packaged)}
+                      onChange={updateControl}
+                      hideLabel
+                    />
+                  </ControlGroup>
+                ))}
+              </div>
+            </section>
+
+            <ScientificPreview preview={preview} />
+          </section>
+
+          <section className="variation-section">
+            <SectionTitle
+              step="3"
+              title="Run profile"
+              detail="Numerical realization and observation plan are explicit parts of the comparison."
+            />
+            <div className="variation-profile-options trade-profile-options" role="radiogroup">
+              {template.run_profiles.map((estimate) => (
+                <label
+                  key={estimate.profile.profile_id}
+                  className={
+                    runProfileId === estimate.profile.profile_id
+                      ? "variation-profile-option selected"
+                      : "variation-profile-option"
+                  }
+                >
+                  <input
+                    type="radio"
+                    name="trade-cumulus-profile"
+                    value={estimate.profile.profile_id}
+                    checked={runProfileId === estimate.profile.profile_id}
+                    disabled={Boolean(packaged)}
+                    onChange={() => setRunProfileId(estimate.profile.profile_id)}
+                  />
+                  <span>
+                    <strong>{estimate.profile.role}</strong>
+                    <small>{shortProfileName(estimate.profile.profile_name)}</small>
+                  </span>
+                  <span
+                    className={
+                      estimate.disposition === "passes" ? "profile-cost" : "profile-cost blocked"
+                    }
+                  >
+                    {profileCost(estimate.profile)}
+                  </span>
+                </label>
+              ))}
+            </div>
+            {selectedProfile && (
+              <div className="variation-profile-detail">
+                <div>
+                  <span>Numerical realization</span>
+                  <strong>
+                    {preview?.numerical_realization.grid ??
+                      selectedProfile.profile.numerical_realization.grid}
+                  </strong>
+                  <small>
+                    {preview?.numerical_realization.spacing ??
+                      selectedProfile.profile.numerical_realization.spacing}
+                  </small>
+                </div>
+                <div>
+                  <span>Observation plan</span>
+                  <strong>
+                    {formatDuration(
+                      preview?.observation_plan.duration_seconds ??
+                        selectedProfile.profile.observation_plan.duration_seconds,
+                    )}
+                  </strong>
+                  <small>
+                    {preview?.observation_plan.expected_history_count ??
+                      selectedProfile.profile.observation_plan.expected_history_count ??
+                      "Generated"}{" "}
+                    saved outputs
+                  </small>
+                </div>
+                <div>
+                  <span>Expected local cost</span>
+                  <strong>
+                    {profileCost(preview?.cost_estimate.profile ?? selectedProfile.profile)}
+                  </strong>
+                  <small>
+                    {(
+                      preview?.cost_estimate.profile.estimate_basis ??
+                      selectedProfile.profile.estimate_basis
+                    ).replaceAll("_", " ")}
+                  </small>
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+
+        <aside className="variation-preview" aria-label="Variation review">
+          <header>
+            <div>
+              <p className="eyebrow">Review</p>
+              <h3>
+                {previewing ? "Resolving experiment..." : `${differenceCount} material changes`}
+              </h3>
+            </div>
+            {preview && preview.blocking_errors.length === 0 && (
+              <span className="technical-state available">Ready to package</span>
+            )}
+          </header>
+
+          {preview && (
+            <>
+              <section className="variation-review-summary">
+                <p className="variation-relationship">
+                  {relationshipLabel(preview.relationship_classification)}
+                </p>
+                <div className="variation-regime-labels">
+                  {preview.diagnostics.labels.map((label) => (
+                    <span key={label}>{label}</span>
+                  ))}
+                </div>
+                <dl className="variation-diagnostics">
+                  <div>
+                    <dt>Inversion</dt>
+                    <dd>{formatDistance(preview.diagnostics.inversion_top_m_agl)} top</dd>
+                  </div>
+                  <div>
+                    <dt>0–3 km shear</dt>
+                    <dd>{preview.diagnostics.cloud_layer_shear_m_s.toFixed(1)} m s⁻¹</dd>
+                  </div>
+                  <div>
+                    <dt>Free-tropospheric RH</dt>
+                    <dd>
+                      {preview.diagnostics.free_tropospheric_rh_percent === null
+                        ? "Unavailable"
+                        : `${preview.diagnostics.free_tropospheric_rh_percent.toFixed(0)}%`}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Initial saturation</dt>
+                    <dd>{preview.diagnostics.initial_saturated_level_count} profile levels</dd>
+                  </div>
+                </dl>
+              </section>
+
+              {preview.warnings.map((warning) => (
+                <p key={warning} className="variation-message variation-message-warning">
+                  {warning}
+                </p>
+              ))}
+              {preview.blocking_errors.map((message) => (
+                <p
+                  key={message}
+                  className="variation-message variation-message-blocking"
+                  role="alert"
+                >
+                  {message}
+                </p>
+              ))}
+
+              <DifferenceReview preview={preview} />
+
+              <CostReview estimate={preview.cost_estimate} />
+
+              {!packaged ? (
+                <button
+                  type="button"
+                  disabled={!canPackage}
+                  onClick={() => void packageVariation()}
+                >
+                  {submitting ? "Packaging..." : "Package variation"}
+                </button>
+              ) : (
+                <section className="variation-packaged-state">
+                  <p className="eyebrow">Packaged</p>
+                  <strong>{packaged.run_id}</strong>
+                  <small>Exact inputs and launch review are retained. CM1 has not started.</small>
+                  <button type="button" disabled={queueing} onClick={() => void queuePackage()}>
+                    {queueing ? "Queueing..." : "Queue CM1"}
+                  </button>
+                </section>
+              )}
+            </>
+          )}
+          {status && <p className="variation-message">{status}</p>}
+          {error && (
+            <p className="variation-message variation-message-blocking" role="alert">
+              {error}
+            </p>
+          )}
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function SectionTitle({ step, title, detail }: { step: string; title: string; detail: string }) {
+  return (
+    <div className="variation-section-title">
+      <span>{step}</span>
+      <div>
+        <h4>{title}</h4>
+        <p>{detail}</p>
+      </div>
+    </div>
+  );
+}
+
+function ControlGroup({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div className="variation-control-group">
+      <h5>{title}</h5>
+      {children}
+    </div>
+  );
+}
+
+function RangeField({
+  controlKey,
+  value,
+  template,
+  disabled,
+  onChange,
+  hideLabel = false,
+}: {
+  controlKey: ControlKey;
+  value: number;
+  template: VariationTemplate;
+  disabled: boolean;
+  onChange: (key: ControlKey, value: number) => void;
+  hideLabel?: boolean;
+}) {
+  const metadata = CONTROL_META[controlKey];
+  const reference = template.canonical_reference_controls[controlKey];
+  const parent = template.controls[controlKey];
+  const difference = value - parent;
+  const inputId = `trade-control-${controlKey}`;
+  return (
+    <label className="variation-range-field" htmlFor={inputId}>
+      {!hideLabel && (
+        <span>
+          <strong>{metadata.label}</strong>
+          <output htmlFor={inputId}>
+            {formatNumber(value, metadata.digits)} {metadata.units}
+          </output>
+        </span>
+      )}
+      {hideLabel && (
+        <output htmlFor={inputId}>
+          {formatNumber(value, metadata.digits)} {metadata.units}
+        </output>
+      )}
+      <div className="variation-range-inputs">
+        <input
+          id={inputId}
+          type="range"
+          min={metadata.min}
+          max={metadata.max}
+          step={metadata.step}
+          value={value}
+          disabled={disabled}
+          onChange={(event) => onChange(controlKey, Number(event.target.value))}
+        />
+        <input
+          type="number"
+          aria-label={`${metadata.label} exact value`}
+          min={metadata.min}
+          max={metadata.max}
+          step={metadata.step}
+          value={value}
+          disabled={disabled}
+          onChange={(event) => {
+            const next = Number(event.target.value);
+            if (Number.isFinite(next)) onChange(controlKey, next);
+          }}
+        />
+      </div>
+      <small>
+        Ref {formatNumber(reference, metadata.digits)} · Parent{" "}
+        {formatNumber(parent, metadata.digits)} · Δ {formatSigned(difference, metadata.digits)}
+      </small>
+    </label>
+  );
+}
+
+function ScientificPreview({ preview }: { preview: VariationPreview | null }) {
+  if (!preview) {
+    return <div className="scientific-preview-placeholder" aria-hidden="true" />;
+  }
+  const heights = preview.sounding_profile.map((level) => level.height_m);
+  const forcingHeights = preview.forcing_profile.map((level) => level.height_m);
+  return (
+    <section className="variation-scientific-preview" aria-labelledby="profile-preview-title">
+      <header>
+        <div>
+          <h5 id="profile-preview-title">Resolved scientific profiles</h5>
+          <p>Complete generated atmosphere and forcing; height is shown in km AGL.</p>
+        </div>
+        <span>Exact package source</span>
+      </header>
+      <div className="variation-atmosphere-profiles trade-profile-plots">
+        <ProfilePlot
+          title="Potential temperature"
+          units="θl (K)"
+          heights={heights}
+          series={[preview.sounding_profile.map((level) => level.theta_l_k)]}
+          markers={[
+            preview.resolved_controls.inversion_base_m_agl ??
+              preview.requested_controls.inversion_base_m_agl,
+            preview.diagnostics.inversion_top_m_agl,
+          ]}
+        />
+        <ProfilePlot
+          title="Total water"
+          units="qt (g/kg)"
+          heights={heights}
+          series={[preview.sounding_profile.map((level) => level.total_water_g_kg)]}
+          markers={[
+            preview.resolved_controls.inversion_base_m_agl ??
+              preview.requested_controls.inversion_base_m_agl,
+            preview.diagnostics.inversion_top_m_agl,
+          ]}
+        />
+        <ProfilePlot
+          title="Relative humidity"
+          units="RH (%)"
+          heights={heights}
+          series={[preview.sounding_profile.map((level) => level.relative_humidity_percent)]}
+          referenceValue={100}
+        />
+        <ProfilePlot
+          title="Horizontal wind"
+          units="u / v (m/s)"
+          heights={heights}
+          series={[
+            preview.sounding_profile.map((level) => level.u_m_s),
+            preview.sounding_profile.map((level) => level.v_m_s),
+          ]}
+        />
+        <ProfilePlot
+          title="Vertical motion"
+          units="w (m/s)"
+          heights={forcingHeights}
+          series={[preview.forcing_profile.map((level) => level.vertical_motion_m_s)]}
+          referenceValue={0}
+        />
+        <ProfilePlot
+          title="Thermodynamic forcing"
+          units="K/day · g/kg/day"
+          heights={forcingHeights}
+          series={[
+            preview.forcing_profile.map((level) => level.temperature_tendency_k_day),
+            preview.forcing_profile.map((level) => level.total_water_tendency_g_kg_day),
+          ]}
+          referenceValue={0}
+        />
+      </div>
+    </section>
+  );
+}
+
+function ProfilePlot({
+  title,
+  units,
+  heights,
+  series,
+  markers = [],
+  referenceValue,
+}: {
+  title: string;
+  units: string;
+  heights: number[];
+  series: number[][];
+  markers?: number[];
+  referenceValue?: number;
+}) {
+  const width = 140;
+  const height = 170;
+  const padding = { left: 23, right: 9, top: 8, bottom: 20 };
+  const values = series.flat();
+  if (!heights.length || !values.length) return null;
+  const minimum = Math.min(...values, referenceValue ?? Infinity);
+  const maximum = Math.max(...values, referenceValue ?? -Infinity);
+  const span = Math.max(maximum - minimum, 1e-9);
+  const top = Math.max(...heights);
+  const x = (value: number) =>
+    padding.left + ((value - minimum) / span) * (width - padding.left - padding.right);
+  const y = (value: number) =>
+    padding.top + (1 - value / Math.max(top, 1)) * (height - padding.top - padding.bottom);
+  const colors = ["var(--color-accent-primary)", "#8b4f7d"];
+  return (
+    <figure className="variation-profile-plot">
+      <figcaption>
+        <strong>{title}</strong>
+        <span>{units}</span>
+      </figcaption>
+      <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label={`${title} profile`}>
+        <line
+          className="profile-axis"
+          x1={padding.left}
+          y1={padding.top}
+          x2={padding.left}
+          y2={height - padding.bottom}
+        />
+        <line
+          className="profile-axis"
+          x1={padding.left}
+          y1={height - padding.bottom}
+          x2={width - padding.right}
+          y2={height - padding.bottom}
+        />
+        {referenceValue !== undefined && (
+          <line
+            className="profile-zero"
+            x1={x(referenceValue)}
+            y1={padding.top}
+            x2={x(referenceValue)}
+            y2={height - padding.bottom}
+          />
+        )}
+        {markers.map((marker) => (
+          <line
+            key={marker}
+            className="profile-marker"
+            x1={padding.left}
+            y1={y(marker)}
+            x2={width - padding.right}
+            y2={y(marker)}
+          />
+        ))}
+        {series.map((valuesForSeries, index) => (
+          <polyline
+            key={index}
+            points={valuesForSeries
+              .map((value, point) => `${x(value)},${y(heights[point])}`)
+              .join(" ")}
+            fill="none"
+            stroke={colors[index] ?? colors[0]}
+            strokeWidth="2.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        ))}
+        <text x={padding.left} y={height - 5}>
+          {compactNumber(minimum)}
+        </text>
+        <text x={width - padding.right} y={height - 5} textAnchor="end">
+          {compactNumber(maximum)}
+        </text>
+        <text x="2" y={padding.top + 6}>
+          {(top / 1000).toFixed(1)}
+        </text>
+        <text x="8" y={height - padding.bottom}>
+          0
+        </text>
+      </svg>
+    </figure>
+  );
+}
+
+function DifferenceReview({ preview }: { preview: VariationPreview }) {
+  const rows = (Object.keys(CONTROL_META) as ControlKey[]).map((key) => {
+    const meta = CONTROL_META[key];
+    const reference = preview.canonical_reference_controls[key];
+    const parent = preview.parent_controls[key];
+    const child = preview.resolved_controls[key];
+    return { key, meta, reference, parent, child };
+  });
+  return (
+    <details className="variation-exact-review" open>
+      <summary>Exact physical specification</summary>
+      <div className="variation-exact-table">
+        <div className="variation-exact-heading">
+          <span>Target</span>
+          <span>Reference</span>
+          <span>Parent</span>
+          <span>Child</span>
+          <span>Δ</span>
+        </div>
+        {rows.map(({ key, meta, reference, parent, child }) => (
+          <div key={key}>
+            <strong>{meta.label}</strong>
+            <span>{formatNumber(reference, meta.digits)}</span>
+            <span>{formatNumber(parent, meta.digits)}</span>
+            <span>{formatNumber(child, meta.digits)}</span>
+            <span>{formatSigned(child === null ? null : child - parent, meta.digits)}</span>
+            <small>{meta.units}</small>
+          </div>
+        ))}
+      </div>
+      <div className="variation-difference-groups">
+        {DIFFERENCE_GROUPS.map((group) => {
+          const differences = preview.differences[group] ?? [];
+          if (!differences.length) return null;
+          return (
+            <section key={group}>
+              <header>
+                <strong>{group}</strong>
+                <span>{differences.length}</span>
+              </header>
+            </section>
+          );
+        })}
+      </div>
+    </details>
+  );
+}
+
+function CostReview({ estimate }: { estimate: RunCostEstimate }) {
+  return (
+    <section className="variation-budget">
+      <dl>
+        <div>
+          <dt>Retained storage</dt>
+          <dd>{storageRange(estimate.profile)}</dd>
+        </div>
+        <div>
+          <dt>Free after high estimate</dt>
+          <dd>{formatBytes(estimate.projected_free_space_bytes)}</dd>
+        </div>
+      </dl>
+      <p className={estimate.disposition === "passes" ? "" : "blocked"}>
+        {estimate.disposition_reason}
+      </p>
+    </section>
+  );
+}
+
+function requestPayload({
+  parentSimulationId,
+  simulationName,
+  userQuestion,
+  runProfileId,
+  controls,
+}: {
+  parentSimulationId: string;
+  simulationName: string;
+  userQuestion: string;
+  runProfileId: string;
+  controls: TradeCumulusControls;
+}) {
+  return {
+    parent_simulation_id: parentSimulationId,
+    simulation_name: simulationName,
+    user_question: userQuestion.trim() || null,
+    recipe_id: "canonical_bomex_trade_cumulus",
+    run_profile_id: runProfileId,
+    controls,
+  };
+}
+
+async function responseMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await response.json()) as { detail?: string };
+    return payload.detail ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function relationshipLabel(value: string | null): string {
+  if (!value) return "No material variation yet";
+  return value
+    .replace("controlled_physical_variation", "Controlled physical variation")
+    .replace("multi_factor_physical_variation", "Multi-factor physical variation")
+    .replace("numerical_sensitivity", "Numerical sensitivity")
+    .replace("mixed_variation", "Mixed physical and numerical variation")
+    .replace("observation_only_attempt", "Observation-only attempt");
+}
+
+function shortProfileName(value: string): string {
+  return value.split("—")[1]?.trim() ?? value;
+}
+
+function profileCost(profile: RunCostProfile): string {
+  const runtime =
+    profile.expected_runtime_min_seconds !== null && profile.expected_runtime_max_seconds !== null
+      ? `${formatDuration(profile.expected_runtime_min_seconds)}–${formatDuration(
+          profile.expected_runtime_max_seconds,
+        )}`
+      : "Uncharacterized";
+  return `${runtime} · ${storageRange(profile)}`;
+}
+
+function storageRange(profile: RunCostProfile): string {
+  if (profile.expected_size_min_bytes === null || profile.expected_size_max_bytes === null) {
+    return "Uncharacterized";
+  }
+  return `${formatBytes(profile.expected_size_min_bytes)}–${formatBytes(
+    profile.expected_size_max_bytes,
+  )}`;
+}
+
+function formatDuration(seconds: number | null): string {
+  if (seconds === null) return "Generated";
+  if (seconds >= 3600) {
+    const hours = seconds / 3600;
+    return Number.isInteger(hours) ? `${hours} h` : `${hours.toFixed(1)} h`;
+  }
+  return `${Math.round(seconds / 60)} min`;
+}
+
+function formatDistance(meters: number): string {
+  return meters >= 1000 ? `${(meters / 1000).toFixed(2)} km` : `${meters.toFixed(0)} m`;
+}
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return "Unknown";
+  return bytes >= 1024 ** 3
+    ? `${(bytes / 1024 ** 3).toFixed(1)} GB`
+    : `${Math.round(bytes / 1024 ** 2)} MB`;
+}
+
+function formatNumber(value: number | null | undefined, digits: number): string {
+  return value === null || value === undefined || !Number.isFinite(value)
+    ? "Unavailable"
+    : value.toFixed(digits);
+}
+
+function formatSigned(value: number | null, digits: number): string {
+  if (value === null || !Number.isFinite(value)) return "Unavailable";
+  const normalized = Math.abs(value) < 10 ** -(digits + 1) ? 0 : value;
+  return `${normalized > 0 ? "+" : ""}${normalized.toFixed(digits)}`;
+}
+
+function compactNumber(value: number): string {
+  const magnitude = Math.abs(value);
+  if (magnitude >= 100) return value.toFixed(0);
+  if (magnitude >= 10) return value.toFixed(1);
+  if (magnitude >= 1) return value.toFixed(2);
+  return value.toFixed(3);
+}

--- a/app/frontend/src/TradeCumulusVariationEditor.tsx
+++ b/app/frontend/src/TradeCumulusVariationEditor.tsx
@@ -191,7 +191,7 @@ const CONTROL_META: Record<
     label: "Inversion base",
     units: "m AGL",
     min: 300,
-    max: 4000,
+    max: 2800,
     step: 10,
     digits: 0,
   },

--- a/app/frontend/src/TradeCumulusWorld.tsx
+++ b/app/frontend/src/TradeCumulusWorld.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { LifecycleWorkspace, type LifecycleRecord } from "./LifecycleWorkspace";
 import { SavedComparisonsCollection } from "./SavedComparisons";
+import { TradeCumulusVariationEditor } from "./TradeCumulusVariationEditor";
 
 export type ConfigurationDifference = {
   path: string;
@@ -23,6 +24,7 @@ export type SimulationRecord = {
   result_id: string;
   run_id: string;
   source_recipe_id: string | null;
+  recipe_contract_version?: string | null;
   parent_simulation_id: string | null;
   reference_simulation_id: string | null;
   technical_state: "available" | "missing" | "conflict";
@@ -36,6 +38,15 @@ export type SimulationRecord = {
   }>;
   configuration_difference_from_reference: ConfigurationDifference[] | null;
   lineage_state: "known" | "valid" | "unlineaged" | "invalid";
+  relationship_classification?: string | null;
+  run_profile_id?: string | null;
+  scientific_design?: Record<string, unknown> | null;
+  numerical_realization?: Record<string, unknown> | null;
+  observation_plan?: Record<string, unknown> | null;
+  configuration?: Record<string, unknown> | null;
+  can_create_variation?: boolean;
+  parent_eligibility_reason?: string | null;
+  attempt_count?: number;
   created_at: string | null;
   completed_at: string | null;
 };
@@ -83,6 +94,7 @@ export type TradeCumulusWorldSection =
   | "comparisons"
   | "saved_comparisons"
   | "activity"
+  | "create"
   | "history";
 
 export function TradeCumulusWorld({
@@ -109,6 +121,7 @@ export function TradeCumulusWorld({
   const [world, setWorld] = useState<TradeCumulusWorldDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [parentSimulationId, setParentSimulationId] = useState<string | null>(null);
 
   const loadWorld = useCallback(async () => {
     setLoading(true);
@@ -118,7 +131,9 @@ export function TradeCumulusWorld({
       if (!response.ok) {
         throw new Error(await responseMessage(response, "Trade Cumulus is unavailable."));
       }
-      setWorld(validateWorldDetail(await response.json()));
+      const payload = validateWorldDetail(await response.json());
+      setWorld(payload);
+      setParentSimulationId((current) => current ?? payload.reference_simulation.simulation_id);
     } catch (caught) {
       setWorld(null);
       setError(caught instanceof Error ? caught.message : "Trade Cumulus is unavailable.");
@@ -138,6 +153,12 @@ export function TradeCumulusWorld({
   function changeSection(target: TradeCumulusWorldSection) {
     if (controlledSection === undefined) setInternalSection(target);
     onSectionChange?.(target);
+  }
+
+  function openVariation(parentId: string | null) {
+    if (!parentId) return;
+    setParentSimulationId(parentId);
+    changeSection("create");
   }
 
   if (loading) {
@@ -188,6 +209,7 @@ export function TradeCumulusWorld({
             "comparisons",
             "saved_comparisons",
             "activity",
+            "create",
             "history",
           ] as TradeCumulusWorldSection[]
         ).map((item) => (
@@ -208,6 +230,7 @@ export function TradeCumulusWorld({
           onExploreSimulation={onExploreSimulation}
           onOpenFeaturedComparison={onOpenFeaturedComparison}
           onOpenActivity={() => changeSection("activity")}
+          onCreateVariation={() => openVariation(world.reference_simulation.simulation_id)}
         />
       )}
       {section === "simulations" && (
@@ -215,6 +238,7 @@ export function TradeCumulusWorld({
           world={world}
           onExploreSimulation={onExploreSimulation}
           onOpenFeaturedComparison={onOpenFeaturedComparison}
+          onCreateVariation={openVariation}
         />
       )}
       {section === "saved_views" && <SavedViewsSection />}
@@ -240,7 +264,21 @@ export function TradeCumulusWorld({
               const simulation = simulationForLifecycleRecord(world, record);
               if (simulation) onOpenFeaturedComparison(simulation);
             }}
-            onOpenRunControls={() => changeSection("activity")}
+            onOpenRunControls={(record) =>
+              openVariation(record.parent_simulation_id ?? world.reference_simulation.simulation_id)
+            }
+          />
+        </section>
+      )}
+      {section === "create" && parentSimulationId && (
+        <section className="world-section" aria-label="Create variation">
+          <TradeCumulusVariationEditor
+            world={world}
+            initialParentSimulationId={parentSimulationId}
+            onCreated={async () => {
+              await loadWorld();
+              changeSection("activity");
+            }}
           />
         </section>
       )}
@@ -265,11 +303,13 @@ function Overview({
   onExploreSimulation,
   onOpenFeaturedComparison,
   onOpenActivity,
+  onCreateVariation,
 }: {
   world: TradeCumulusWorldDetail;
   onExploreSimulation: (simulation: SimulationRecord) => void;
   onOpenFeaturedComparison: (simulation?: SimulationRecord) => void;
   onOpenActivity: () => void;
+  onCreateVariation: () => void;
 }) {
   const moreMoisture = world.simulations.find(
     (simulation) =>
@@ -310,6 +350,19 @@ function Overview({
         )}
       </div>
 
+      <section className="world-create-variation-callout">
+        <div>
+          <p className="eyebrow">Experiment</p>
+          <h3>Design a related atmosphere</h3>
+          <p>
+            Change physical targets, inspect the generated profile, and package a new Simulation.
+          </p>
+        </div>
+        <button type="button" onClick={onCreateVariation}>
+          Create Variation
+        </button>
+      </section>
+
       <section className="world-lab-summary" aria-label="Trade Cumulus Activity status">
         <div>
           <p className="eyebrow">Activity</p>
@@ -328,10 +381,12 @@ function SimulationsSection({
   world,
   onExploreSimulation,
   onOpenFeaturedComparison,
+  onCreateVariation,
 }: {
   world: TradeCumulusWorldDetail;
   onExploreSimulation: (simulation: SimulationRecord) => void;
   onOpenFeaturedComparison: (simulation?: SimulationRecord) => void;
+  onCreateVariation: (simulationId: string | null) => void;
 }) {
   return (
     <section className="world-section" aria-labelledby="world-simulations-title">
@@ -353,6 +408,7 @@ function SimulationsSection({
             comparisonAvailable={world.featured_comparison.open_available}
             onExplore={onExploreSimulation}
             onCompare={() => onOpenFeaturedComparison(simulation)}
+            onCreateVariation={() => onCreateVariation(simulation.simulation_id)}
           />
         ))}
       </div>
@@ -365,11 +421,13 @@ function SimulationCard({
   comparisonAvailable,
   onExplore,
   onCompare,
+  onCreateVariation,
 }: {
   simulation: SimulationRecord;
   comparisonAvailable: boolean;
   onExplore: (simulation: SimulationRecord) => void;
   onCompare: () => void;
+  onCreateVariation?: () => void;
 }) {
   const differences = simulation.configuration_difference_from_reference ?? [];
   const materialDifferences = differences.filter((difference) => difference.material);
@@ -423,6 +481,25 @@ function SimulationCard({
             <dt>Runtime integrity</dt>
             <dd>{trustLabel(simulation.technical_trust_state)}</dd>
           </div>
+          {simulation.source_recipe_id && (
+            <div>
+              <dt>Recipe</dt>
+              <dd>
+                {simulation.source_recipe_id.replaceAll("_", " ")}
+                {simulation.recipe_contract_version
+                  ? ` · contract ${simulation.recipe_contract_version}`
+                  : ""}
+              </dd>
+            </div>
+          )}
+          <div>
+            <dt>Parent eligibility</dt>
+            <dd>
+              {simulation.can_create_variation
+                ? "Eligible"
+                : (simulation.parent_eligibility_reason ?? "Not eligible")}
+            </dd>
+          </div>
         </dl>
       </details>
       <div className="simulation-actions">
@@ -436,6 +513,11 @@ function SimulationCard({
         {comparisonAvailable && simulation.compare_suggestions.length > 0 && (
           <button type="button" className="secondary-button" onClick={onCompare}>
             Compare
+          </button>
+        )}
+        {simulation.can_create_variation && onCreateVariation && (
+          <button type="button" className="secondary-button" onClick={onCreateVariation}>
+            Create variation
           </button>
         )}
       </div>
@@ -552,6 +634,8 @@ function isSimulation(value: unknown): value is SimulationRecord {
     ["available", "missing", "conflict"].includes(String(value.technical_state)) &&
     typeof value.technical_state_message === "string" &&
     typeof value.explore_available === "boolean" &&
+    (value.can_create_variation === undefined || typeof value.can_create_variation === "boolean") &&
+    (value.attempt_count === undefined || typeof value.attempt_count === "number") &&
     Array.isArray(value.compare_suggestions) &&
     (value.configuration_difference_from_reference === null ||
       (Array.isArray(value.configuration_difference_from_reference) &&
@@ -629,6 +713,7 @@ function sectionLabel(section: TradeCumulusWorldSection): string {
     comparisons: "Comparisons",
     saved_comparisons: "Saved Comparisons",
     activity: "Activity",
+    create: "Create Variation",
     history: "History",
   }[section];
 }

--- a/docs/DOCUMENTATION_STATUS.md
+++ b/docs/DOCUMENTATION_STATUS.md
@@ -48,7 +48,7 @@ Keep product approval separate from software availability:
 | Fun With Soundings | A separate first-class atmospheric workbench | Accessible with five jobs, direct non-World Explore, and conservative World ownership |
 | Saved Views | Durable user-curated views | Implemented across all three accessible Worlds as named live examinations with bounded restoration status |
 | Compare | Related Simulations can be compared | Ordinary Compare and durable Saved Comparisons are implemented for real pairs across all three Worlds |
-| Variation | Create a related Simulation from a World Simulation | A shared versioned envelope is implemented with two typed Mountain Waves Recipes; Trade Cumulus and Supercells do not yet provide Recipe payloads |
+| Variation | Create a related Simulation from a World Simulation | A shared versioned envelope is implemented with two typed Mountain Waves Recipes and one direct-value Trade Cumulus Recipe; Supercells does not yet provide a Recipe payload |
 | Activity and History | Owner-aware current work and durable scientific records | One shared lifecycle projection is implemented for current World work, Fun With Soundings, and legacy/unassigned Experiments |
 | Storage and launch budget | Understand retained scientific assets before creating more | Global read-only inventory, dependency visibility, typed World cost profiles, planning and exact-package-bound immutable snapshots, and a single-use immediate prelaunch disk gate are implemented |
 | Explore | World-specific science in a shared application vocabulary | Implemented separately for all three accessible Worlds |
@@ -102,8 +102,10 @@ completes the owner-aware Activity and History lifecycle foundation.
 Issue #436 completes the read-only retained-asset inventory and prelaunch disk
 budget foundation. Issue #447 adds the shared variation envelope and migrates
 Mountain Waves through the approved Dry Ridge Mechanics and Boulder Moist Wave
-Recipes. The next approved sequence is #448 and #449. Their current issue
-bodies and latest explicit PM comments control exact scope when activated.
+Recipes. Issue #448 is the active direct-value Trade Cumulus Recipe
+implementation; manual review and separately authorized bounded
+characterization remain. Issue #449 follows it. Their current issue bodies and
+latest explicit PM comments control exact scope when activated.
 Issues #389, #390, and #391 were closed as superseded and are not current
 assignment authority.
 

--- a/docs/current/CURRENT_ARCHITECTURE.md
+++ b/docs/current/CURRENT_ARCHITECTURE.md
@@ -481,6 +481,14 @@ Mechanics and Boulder Moist Wave Recipe controls. Deterministic generators
 resolve those controls into complete sounding, terrain, domain, timing, output,
 diagnostic, and run-cost specifications.
 
+Trade Cumulus implements its separate typed direct-value payload in
+`app/backend/cloud_chamber/trade_cumulus_recipes.py`. Its generator resolves
+signed surface exchange, absolute atmosphere and wind targets, and signed
+large-scale forcing into complete external sounding and forcing profiles. The
+package layer in `trade_cumulus_variations.py` binds those profiles to the
+source-locked BOMEX implementation, explicit run profile, output contract,
+immutable launch review, and generated-input readback.
+
 Package identity is derived from the immutable layers. The same specification
 therefore resolves to the same intended Simulation identity, while each
 packaging creates a distinct technical attempt and run ID. Exact inheritance,
@@ -493,6 +501,16 @@ The Mountain Waves API keeps preview, package, and queue separate:
 GET  /api/worlds/mountain-waves/variation-template
 POST /api/worlds/mountain-waves/variations/preview
 POST /api/worlds/mountain-waves/variations
+POST /api/runs/queue
+```
+
+Trade Cumulus uses the same lifecycle separation:
+
+```text
+GET  /api/worlds/trade-cumulus/variation-template
+POST /api/worlds/trade-cumulus/variations/preview
+POST /api/worlds/trade-cumulus/variations
+POST /api/worlds/trade-cumulus/variations/preflight
 POST /api/runs/queue
 ```
 
@@ -600,8 +618,11 @@ only in a transient unsaved pair.
 
 Saved Comparisons do not write the per-Simulation Explore-state library or
 mutate either Simulation. Compare consumes the shared envelope relationship and
-material differences for Mountain Waves parent-child pairs. Other Worlds do not
-yet provide typed Recipe payloads to the common variation envelope.
+material differences for Mountain Waves and Trade Cumulus parent-child pairs.
+It derives Trade Cumulus grid, timeline, and normalized differences from the
+retained immutable layers rather than assuming the built-in Presentation pair.
+Supercells does not yet provide a typed Recipe payload to the common variation
+envelope.
 
 ## Product and Research Boundaries
 
@@ -620,8 +641,9 @@ reused.
 - World shells and Explore implementations share vocabulary but still contain
   World-specific state and rendering code.
 - Saved Comparisons are local filesystem state and do not synchronize across devices.
-- The shared variation envelope is implemented, but only Mountain Waves
-  currently provides typed Recipe payloads and a Create Variation surface.
+- The shared variation envelope is implemented for Mountain Waves and Trade
+  Cumulus; Supercells does not yet provide a typed Recipe payload or Create
+  Variation surface.
 - Legacy run, result, and sounding surfaces remain interleaved with the newer
   World application.
 - Filesystem-backed runtime metadata is local and not a durable multi-device

--- a/docs/current/CURRENT_STATE.md
+++ b/docs/current/CURRENT_STATE.md
@@ -68,8 +68,8 @@ retained Experiments open directly in non-World Explore.
 
 | World | Current content | Current surfaces | Current limitation |
 | --- | --- | --- | --- |
-| **Trade Cumulus** | Canonical BOMEX Baseline and More Moisture retained Simulations | Overview, Simulations, Activity, History, featured and ordinary Compare, Saved Comparisons, Explore resume, and Saved Views | Shared variation creation is not implemented |
-| **Mountain Waves** | Dry Ridge and Boulder Windstorm retained Simulations | Overview, Simulations, Activity, History, ordinary Compare, Saved Comparisons, shared-contract Create Variation, Explore resume, and Saved Views | The first shared variation envelope is implemented; other Worlds do not yet supply Recipe payloads |
+| **Trade Cumulus** | Canonical BOMEX Baseline and More Moisture retained Simulations | Overview, Simulations, Activity, History, featured and ordinary Compare, Saved Comparisons, direct-value Create Variation, Explore resume, and Saved Views | Standard and Extended profile characterization remains separately gated |
+| **Mountain Waves** | Dry Ridge and Boulder Windstorm retained Simulations | Overview, Simulations, Activity, History, ordinary Compare, Saved Comparisons, shared-contract Create Variation, Explore resume, and Saved Views | The first shared variation envelope remains the reference implementation |
 | **Supercells** | Quarter-Circle and Straight-Line Hodograph retained Simulations | Overview, Simulations, Activity, History, ordinary Compare, Saved Comparisons, Explore resume, and Saved Views | No create-variation workflow |
 
 The World Overview and Simulations surfaces use stable content identities and
@@ -98,8 +98,9 @@ and attempt relationships with text search, practical filters, and sort.
 Technical identifiers, differences, caveats, dependencies, and attempt evidence
 remain available on demand.
 
-Current shared-envelope Mountain Waves variations can be assigned to their
-World when their Recipe identity and current contract evidence are present.
+Current shared-envelope Mountain Waves and Trade Cumulus variations can be
+assigned to their World when their Recipe identity and current contract
+evidence are present.
 Availability is evaluated independently from parent eligibility. A World name
 or Simulation string by itself does not establish ownership. Sounding-related
 work remains under Fun With Soundings, while ambiguous records remain visibly
@@ -107,7 +108,7 @@ legacy or unassigned.
 
 ## Create Variation
 
-Mountain Waves is the first consumer of the shared variation envelope. The
+Mountain Waves and Trade Cumulus consume the shared variation envelope. The
 envelope records stable intended Simulation identity, parent and reference
 lineage, immutable scientific, numerical, and observation layers, categorized
 material differences, relationship classification, explicit run profile,
@@ -120,6 +121,14 @@ Two versioned Mountain Waves Recipes are implemented:
   wind, shear, and stability controls;
 - Boulder Moist Wave, using absolute transforms against the retained
   source-backed Boulder reference for terrain, wind, moisture, and stability.
+
+The versioned Canonical BOMEX Trade Cumulus Recipe exposes signed surface heat
+and moisture fluxes, direct thermodynamic and wind-profile targets, and direct
+large-scale vertical-motion, temperature-tendency, and total-water-tendency
+targets. Its preview shows complete generated atmosphere and forcing profiles,
+exact canonical/parent/child/delta review, all five explicit run profiles, and
+the package-bound storage gate. Unusual but coherent atmospheric states warn
+rather than fail. Packaging remains separate from queueing.
 
 The selected parent determines the Recipe. Controls resolve against the Recipe
 reference rather than compounding relative to a previous variation. Quick,
@@ -135,9 +144,8 @@ Storage. Packaging or process success does not imply Simulation availability.
 
 Validated completed output is made available automatically when current World
 inspectability passes. Parent eligibility is a separate decision. Existing
-out-of-contract Mountain Waves variations remain visible as Legacy-contract
-history and may remain inspectable or comparable, but cannot parent a new
-Recipe variation.
+out-of-contract variations remain visible as Legacy-contract history and may
+remain inspectable or comparable, but cannot parent a new Recipe variation.
 
 ## Explore Experiences
 

--- a/docs/product/CLOUD_WORLD_VARIATION_CONTRACTS.md
+++ b/docs/product/CLOUD_WORLD_VARIATION_CONTRACTS.md
@@ -595,41 +595,60 @@ Ineligible:
 
 ## 8.3 Surface-exchange controls
 
-These are ordinary controls. They are independent, so the user can explore both total forcing and the balance between heat and moisture supply.
+These are independent direct physical controls. The reviewed and persisted
+specification records signed target values rather than reference multipliers.
 
-| Control | Recipe-reference mapping | Supported envelope | Evidence and product treatment |
+| Control | User-facing value | Supported envelope | Reference and interpretation |
 | --- | --- | --- | --- |
-| **Surface moisture supply** | Absolute factor applied to canonical `5.2e-5 g/g m/s` | `0.50–1.75×`; named stops at `0.50, 0.75, 1.00, 1.25, 1.50, 1.75` | Baseline and `1.50×` are measured. Full envelope requires bounded endpoint characterization. |
-| **Surface sensible heating** | Absolute factor applied to canonical `8.0e-3 K m/s` | `0.50–1.50×`; named stops at `0.50, 0.75, 1.00, 1.25, 1.50` | Scientifically grounded but not yet measured in the product. |
+| **Surface sensible-heat flux** | Signed kinematic flux, `K m s⁻¹` | `−0.020` to `+0.050` | Canonical reference `+0.008`; negative values mean surface cooling |
+| **Surface moisture flux** | Signed kinematic flux, `g kg⁻¹ m s⁻¹` | `−0.10` to `+0.25` | Canonical reference `+0.052`; negative values mean downward moisture exchange |
 
-The review shows both actual flux values and a concise derived **heat-to-moisture supply balance**. Negative fluxes and values outside the envelope are blocked.
+The review shows the canonical reference, selected parent, requested child, and
+exact parent-to-child difference. Reference-relative values may be offered as
+shortcuts, but the child specification and generated package contain the
+resolved direct values.
 
 ## 8.4 Atmospheric-structure controls
 
-These are ordinary or advanced curated profile transforms. They are calculated from the Recipe reference, not from the latest parent profile.
+These curated transforms resolve absolute target metrics through the canonical
+Recipe generator. They do not compound a child's prior transform.
 
-| Control | Exact transform | Supported envelope | Placement and validation |
+| Control | Direct target | Supported envelope | Generation behavior |
 | --- | --- | --- | --- |
-| **Boundary-layer moisture** | Add a vertically tapered total-water offset below the inversion; zero perturbation above the inversion top | `−1.5 to +1.5 g/kg` | Ordinary. Block initial supersaturation or negative water vapor. |
-| **Trade inversion height** | Shift the authored inversion base and top together, remapping the reference profile continuously | `−300 to +400 m` | Ordinary. Preserve minimum cloud layer and free-tropospheric depth. |
-| **Trade inversion strength** | Scale the reference liquid-water-potential-temperature jump while preserving the subcloud profile and upper anchor | `0.50–1.50×` | Ordinary. Require static stability and continuous profile. |
-| **Free-tropospheric humidity** | Scale the reference relative-humidity deficit above the inversion, then derive qv from pressure and temperature | deficit factor `0.50–2.00×` | Ordinary. Bound RH to `5–95%` and prevent initial cloud outside a separately authored cloudy-initial-state Recipe. |
-| **Cloud-layer wind shear** | Scale departures from the 0–3 km layer-mean reference wind while preserving that mean | `0–2.00×` | Advanced. Show resulting shear and wind profile. |
+| **Sub-inversion moisture** | Mean total-water mixing ratio below inversion base, `g kg⁻¹` | `0` to `25` | Preserve the authored vertical shape while solving the requested layer mean |
+| **Inversion base** | `m AGL` | `300` to `4,000` | Absolute base target |
+| **Inversion thickness** | `m` | `50` to `2,000` | Advanced direct field; preserve a continuous profile |
+| **Inversion strength** | Liquid-water-potential-temperature jump, `K` | `−5` to `+20` | Weak, absent, or reversed inversion is permitted and warned |
+| **Free-tropospheric humidity** | Layer-mean RH above the inversion through the authored free-tropospheric layer, `%` | `0` to `100` | Solve and report the achieved layer mean |
+| **Cloud-layer shear** | `0–3 km` vector-shear magnitude, `m s⁻¹` | `0` to `50` | Preserve the separately exposed layer-mean wind |
+| **Shear direction** | Vector bearing, degrees | `0` to `360` | Advanced; inactive when shear is zero |
 
-The product shows the resulting profiles, inversion markers, initial relative humidity, static stability, and wind shear before launch.
+The product shows the complete resulting theta, total-water, RH, and wind
+profiles; inversion markers; static stability; initial cloud or saturation
+state; and achieved target values before packaging.
 
 ## 8.5 Large-scale-forcing controls
 
-The large-scale forcings remain physically distinct. The user may change them together through a named **Large-scale forcing strength** control or reveal the individual advanced controls.
+The large-scale forcings remain physically distinct signed direct values.
+There is no generic forcing-strength multiplier.
 
-| Control | Transform | Supported envelope |
+| Control | Direct target | Supported envelope |
 | --- | --- | --- |
-| **Large-scale forcing strength** | Scale subsidence, prescribed cooling, and prescribed drying together from the Recipe reference | `0.75–1.25×` ordinary; `0.50–1.50×` advanced |
-| **Subsidence strength** | Scale the complete authored subsidence profile | `0.50–1.50×` advanced |
-| **Prescribed cooling** | Scale the complete authored cooling profile | `0.50–1.50×` advanced |
-| **Prescribed drying** | Scale the complete authored drying profile | `0.50–1.50×` advanced |
+| **Large-scale vertical motion** | Signed peak authored-profile vertical velocity, `m s⁻¹` | `−0.050` to `+0.050` |
+| **Temperature tendency** | Signed peak authored-profile tendency, `K day⁻¹` | `−20` to `+10` |
+| **Total-water tendency** | Signed peak authored-profile tendency, `g kg⁻¹ day⁻¹` | `−20` to `+10` |
 
-Changing individual components is a legitimate multi-factor balance experiment, not an error. The preview must show the complete resulting tendency profiles and must not imply steady-state preservation.
+Negative vertical motion is subsidence and positive is ascent. Negative
+temperature and total-water tendencies are cooling and drying; positive values
+are warming and moistening. **Restore reference forcing** and **Zero forcing**
+set all three fields visibly. The preview shows their complete authored
+profiles and does not imply steady-state preservation.
+
+Odd, weak, cloud-free, initially cloudy, strongly forced, stably stratified,
+unstable, or otherwise surprising requests are valid experiments. They receive
+prominent warnings or caveats. Block only nonfinite values, incoherent or
+unattainable generated profiles, unsafe or impossible numerical/domain
+contracts, and execution or storage safety failures.
 
 ## 8.6 Fixed or separate-Recipe choices
 
@@ -659,10 +678,14 @@ Control choices may alter adaptive timestep behavior. The prelaunch range must w
 
 ## 8.8 Trade Cumulus dependencies and comparison rules
 
-- A controlled surface-moisture experiment requires every other physical control and the numerical realization to match.
-- Changing Surface moisture supply while switching Presentation to Standard creates a mixed variation.
+- A controlled surface-moisture-flux experiment requires every other physical
+  control and the numerical realization to match.
+- Changing Surface moisture flux while switching Presentation to Standard
+  creates a mixed variation.
 - When a lower-cost controlled pair is desired, Cloud Chamber should offer to create or select a same-profile reference, not pretend the Presentation parent is numerically matched.
-- Atmospheric profile transforms must preserve positive pressure, finite values, static stability where the Recipe requires it, and no unintended initial cloud.
+- Atmospheric profile transforms must preserve positive pressure and finite,
+  coherent values. Static instability and initial cloud are warned rather than
+  rejected when the exact requested state can be generated safely.
 - Inversion changes must retain enough vertical domain above the inversion.
 - Large-scale forcing profiles must retain their authored vertical support and smoothness.
 - No physical-response threshold is required for availability. No cloud or a weak response may be the result.

--- a/docs/product/CLOUD_WORLD_VARIATION_CONTRACTS.md
+++ b/docs/product/CLOUD_WORLD_VARIATION_CONTRACTS.md
@@ -616,7 +616,7 @@ Recipe generator. They do not compound a child's prior transform.
 | Control | Direct target | Supported envelope | Generation behavior |
 | --- | --- | --- | --- |
 | **Sub-inversion moisture** | Mean total-water mixing ratio below inversion base, `g kg⁻¹` | `0` to `25` | Preserve the authored vertical shape while solving the requested layer mean |
-| **Inversion base** | `m AGL` | `300` to `4,000` | Absolute base target |
+| **Inversion base** | `m AGL` | `300` to `2,800` | Absolute base target; the upper bound preserves room for the minimum inversion thickness beneath the 3 km Standard model top |
 | **Inversion thickness** | `m` | `50` to `2,000` | Advanced direct field; preserve a continuous profile |
 | **Inversion strength** | Liquid-water-potential-temperature jump, `K` | `−5` to `+20` | Weak, absent, or reversed inversion is permitted and warned |
 | **Free-tropospheric humidity** | Layer-mean RH above the inversion through the authored free-tropospheric layer, `%` | `0` to `100` | Solve and report the achieved layer mean |
@@ -643,6 +643,13 @@ temperature and total-water tendencies are cooling and drying; positive values
 are warming and moistening. **Restore reference forcing** and **Zero forcing**
 set all three fields visibly. The preview shows their complete authored
 profiles and does not imply steady-state preservation.
+
+Every Trade Cumulus package retains the native CM1 domain-diagnostic stream at
+60-second cadence from model time zero through completion. Availability and
+descendant eligibility require finite `wprof`, `ptb_frc`, and `qvb_frc`
+profiles at every diagnostic time, with native units and vertical support that
+reproduce the reviewed direct forcing targets. Packaged source changes alone
+are not forcing evidence.
 
 Odd, weak, cloud-free, initially cloudy, strongly forced, stably stratified,
 unstable, or otherwise surprising requests are valid experiments. They receive
@@ -675,6 +682,12 @@ All profiles retain the required Trade Cumulus Explore and Updraft Lens fields, 
 | **Extended — Wide-domain organization** | `128×128×75`; `100×100×40 m`; target `dt=3 s`; 12.8 km horizontal domain | `14,400 s`; `120 s`; 121 histories | provisional `60–120 min`; `6.5–9 GB` | Requires characterization | Domain-size and organization sensitivity; not the ordinary default |
 
 Control choices may alter adaptive timestep behavior. The prelaunch range must widen when prior local evidence shows that a control state runs materially slower.
+
+Issue #448 authorizes exactly one reference-control Extended package for
+bounded cost characterization. That package uses the ordinary immutable
+package, snapshot, disk, provenance, diagnostics, and output-validation paths,
+but remains visibly a characterization and does not enable Extended for
+ordinary variation creation.
 
 ## 8.8 Trade Cumulus dependencies and comparison rules
 

--- a/docs/product/CURRENT_PRODUCT_SEQUENCE.md
+++ b/docs/product/CURRENT_PRODUCT_SEQUENCE.md
@@ -234,7 +234,8 @@ The approved sequence is:
 #394 — shared Activity and History — complete
 #436 — retained-asset inventory and prelaunch disk budget — complete
 #447 — shared variation envelope and Mountain Waves migration — complete
-#448 — queued after #447
+#448 — Trade Cumulus direct-value Recipe implementation — active; manual
+       review and bounded characterization authorization remain
 #449 — queued after #448
 ```
 
@@ -245,8 +246,11 @@ inventory, World run-cost profiles, immutable launch-review snapshots, and
 immediate prelaunch disk gate. Issue #447 adds the versioned shared variation
 envelope and migrates Mountain Waves to exact Dry Ridge Mechanics and Boulder
 Moist Wave Recipe payloads with separate preview, package, queue, availability,
-and parent-eligibility states. Issues #448 and #449 remain next. Their current
-bodies and latest explicit PM comments control exact scope when activated.
+and parent-eligibility states. Issue #448 is the active Trade Cumulus
+direct-value Recipe implementation. Its manual review and separately authorized
+bounded characterization gate remain before completion. Issue #449 remains
+queued after it. Their current bodies and latest explicit PM comments control
+exact scope when activated.
 
 Do not copy current Trade Cumulus or Mountain Waves controls into another World
 without its approved contract. The user may change several supported settings


### PR DESCRIPTION
## Summary

- implement the versioned `canonical_bomex_trade_cumulus` direct-value Recipe through the shared variation envelope and Create Variation shell
- generate and read back exact sounding, forcing, namelist, lineage, run-profile, storage-gate, execution-provenance, forcing-diagnostic, and output-validation contracts
- integrate intended Simulation identity, attempts, Activity/History, automatic availability, parent eligibility, Explore, Compare, and descendant reuse
- update the approved variation authority to the PM-approved `300–2,800 m AGL` inversion-base envelope

## Reviewer rework

- availability proves the exact reviewed grid dimensions, spacing, domain bounds, model top, complete timeline from 0 through the reviewed duration, and attempt-directory containment
- every launch records the SHA-256 of the executable actually invoked; canonical and customized attempts validate command path, launch-time hash, retained executable identity, and approved provenance before Availability or parent reuse
- Trade Cumulus packages retain `cm1out_diag_*.nc` forcing diagnostics every 60 seconds and validate the complete timeline, dimensions, units, vertical grid, finite values, and exact `wprof`, `ptb_frc`, and `qvb_frc` profiles before Availability or parent reuse
- forcing-modified attempts bind the packaged customization, approved original source, patched source hash, isolated build status, retained custom executable, actual execution command, forcing readback, and retained surface-flux diagnostics
- the immediate disk gate runs again after source staging/build and immediately before process creation; the queue consumes that final disposition
- every attempt grouped under one Simulation ID must share one canonical intended-Simulation contract, including lineage, differences, relationship, Recipe payload, name, and question
- one explicit PM-authorized endpoint can package exactly one canonical Extended reference characterization; ordinary Extended selection remains visibly blocked and the result remains parent-ineligible until separate PM acceptance
- the launch review shows current free space, required reserve, exact domain/grid/timestep, cadence and frame count, retained fields, evidence and limitations, heat-to-moisture balance, and source-build storage implications

## Product-drift check

**Stable vision:** Cloud Chamber remains one local personal atmospheric laboratory with scientifically honest, persisted, explorable Simulations.

**Current task:** This implements the approved Trade Cumulus direct-value variation contract through the already-approved shared envelope and lifecycle.

**Non-implications:** This does not add a World or Recipe, change Supercells, expose free-form CM1 numerics, add patch forcing or precipitation, run CM1, or generally enable Extended.

**Portfolio effect:** This broadens Trade Cumulus experiments without narrowing the rest of Cloud Chamber.

## Verification

- `BACKEND_PYTHON=/Users/timpeterson/Documents/Codex/cloud-chamber/app/backend/.venv/bin/python scripts/check.sh`
  - 265 frontend tests passed
  - 844 backend tests passed
  - lint, TypeScript/Vite build, Ruff, mypy, syntax, artifact, and docs/config checks passed
- live desktop browser review:
  - inversion-base input exposes the approved `300–2,800 m AGL` range
  - ordinary Extended selection resolves to the explicit uncharacterized block and disabled package action
  - forcing/profile review and run-profile cards remain readable without horizontal overflow
- the exact forcing-profile formulas were checked against all 241 retained `cm1out_diag_*.nc` files from the canonical presentation baseline; maximum absolute errors were `4.83e-10 m/s` for `wprof`, `1.14e-12 K/s` for `ptb_frc`, and `3.23e-16 g/g/s` for `qvb_frc`

Known nonblocking output: the existing NumPy ABI runtime warning and Vite chunk-size warning remain unchanged.

## Characterization gate: no CM1 process started

This PR creates the deterministic package and validation path but starts no CM1 process. The bounded future plan remains seven Standard cases plus one exact PM-authorized Extended reference characterization, with no Presentation rerun or unrestricted parameter sweep. Every future launch must independently pass the package-bound free-space gate and preserve the required 2 GB reserve.

Closes #448
